### PR TITLE
Add ability to apply directives to dynamic component

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -148,6 +148,79 @@ class MyComponent {
 }
 ```
 
+### Directives
+
+**Since v3.0.0** you can now declaratively set directives, via `ndcDynamicDirectives`:
+
+**NOTE**: In dynamic directives queries like `@ContentChild` and host decorators like `@HostBinding`
+will not work due to involved complexity required to handle it (but PRs are welcome!).
+
+```ts
+import { dynamicDirectiveDef } from 'ng-dynamic-component';
+
+@Component({
+  selector: 'my-component',
+  template: `<ng-container [ngComponentOutlet]="component"
+                           [ndcDynamicDirectives]="dirs"
+                           ></ng-container>`
+})
+class MyComponent {
+  component = MyDynamicComponent1;
+  dirs = [dynamicDirectiveDef(MyDirective)];
+}
+```
+
+It's also possible to bind inputs and outputs to every dynamic directive:
+
+```ts
+import { dynamicDirectiveDef } from 'ng-dynamic-component';
+
+@Component({
+  selector: 'my-component',
+  template: `<ng-container [ngComponentOutlet]="component"
+                           [ndcDynamicDirectives]="dirs"
+                           ></ng-container>`
+})
+class MyComponent {
+  component = MyDynamicComponent1;
+  directiveInputs = { prop1: 'value' };
+  directiveOutputs = { output1: (evt) => this.doSomeStuff(evt) };
+  dirs = [dynamicDirectiveDef(MyDirective, this.directiveInputs, this.directiveOutputs)];
+}
+```
+
+To change inputs, just update the object:
+
+```ts
+class MyComponent {
+  updateDirectiveInput() {
+    this.directiveInputs.prop1 = 'new value';
+  }
+}
+```
+
+You can have multiple directives applied to same dynamic component (only one directive by same type):
+
+```ts
+import { dynamicDirectiveDef } from 'ng-dynamic-component';
+
+@Component({
+  selector: 'my-component',
+  template: `<ng-container [ngComponentOutlet]="component"
+                           [ndcDynamicDirectives]="dirs"
+                           ></ng-container>`
+})
+class MyComponent {
+  component = MyDynamicComponent1;
+  dirs = [
+    dynamicDirectiveDef(MyDirective1),
+    dynamicDirectiveDef(MyDirective2),
+    dynamicDirectiveDef(MyDirective3),
+    dynamicDirectiveDef(MyDirective1), // This will be ignored because MyDirective1 already applied above
+  ];
+}
+```
+
 ### NgComponentOutlet support
 
 You can also use [`NgComponentOutlet`](https://angular.io/docs/ts/latest/api/common/index/NgComponentOutlet-directive.html)

--- a/src/dynamic/dynamic-directives.directive.spec.ts
+++ b/src/dynamic/dynamic-directives.directive.spec.ts
@@ -1,0 +1,579 @@
+import {
+  AfterContentChecked,
+  AfterContentInit,
+  AfterViewChecked,
+  AfterViewInit,
+  ChangeDetectorRef,
+  Directive,
+  ElementRef,
+  Input,
+  OnChanges,
+  OnDestroy,
+  OnInit,
+  Output,
+  SimpleChange,
+  ViewContainerRef,
+} from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { Subject } from 'rxjs';
+
+import {
+  ComponentInjectorComponent,
+  getDirective,
+  InjectedBoundComponent,
+  InjectedComponent,
+  MockedInjectedComponent,
+  TestComponent,
+  TestModule,
+} from '../test/index';
+import { COMPONENT_INJECTOR } from './component-injector';
+import { ComponentOutletInjectorDirective } from './component-outlet-injector.directive';
+import {
+  DirectiveRef,
+  dynamicDirectiveDef,
+  DynamicDirectivesDirective,
+} from './dynamic-directives.directive';
+import { IoFactoryService } from './io-factory.service';
+
+const getComponentInjectorFrom = getDirective(ComponentInjectorComponent);
+const getInjectedComponentFrom = getDirective(InjectedComponent);
+const getInjectedBoundComponentFrom = getDirective(InjectedBoundComponent);
+
+@Directive({ selector: 'mock' })
+class MockDirective
+  implements OnInit,
+    OnDestroy,
+    OnChanges,
+    AfterViewInit,
+    AfterViewChecked,
+    AfterContentInit,
+    AfterContentChecked {
+  static INSTANCES = new Set<MockDirective>();
+  @Input() in: any;
+  @Input() in2: any;
+  @Output() out = new Subject<any>();
+  @Output() out2 = new Subject<any>();
+  ngAfterContentChecked = jest.fn().mockImplementation(this.logHook('ngAfterContentChecked'));
+  ngAfterContentInit = jest.fn().mockImplementation(this.logHook('ngAfterContentInit'));
+  ngAfterViewChecked = jest.fn().mockImplementation(this.logHook('ngAfterViewChecked'));
+  ngAfterViewInit = jest.fn().mockImplementation(this.logHook('ngAfterViewInit'));
+  ngOnChanges = jest.fn().mockImplementation(this.logHook('ngOnChanges'));
+  ngOnInit = jest.fn().mockImplementation(this.logHook('ngOnInit'));
+  ngOnDestroy = jest.fn().mockImplementation(() => {
+    this.hooksOrder.push('ngOnDestroy');
+    MockDirective.INSTANCES.delete(this);
+  });
+  hooksOrder = [];
+  constructor() {
+    MockDirective.INSTANCES.add(this);
+  }
+  private logHook(name: string) {
+    return () => this.hooksOrder.push(name);
+  }
+}
+
+@Directive({ selector: 'mock2' })
+class Mock2Directive extends MockDirective {}
+
+describe('Directive: DynamicDirectives', () => {
+  beforeEach(() => {
+    MockDirective.INSTANCES.clear();
+    TestBed.configureTestingModule({
+      imports: [TestModule],
+      declarations: [
+        DynamicDirectivesDirective,
+        TestComponent,
+        ComponentInjectorComponent,
+        ComponentOutletInjectorDirective,
+      ],
+      providers: [
+        { provide: COMPONENT_INJECTOR, useValue: ComponentInjectorComponent },
+        IoFactoryService,
+      ],
+    });
+  });
+
+  describe('directives', () => {
+    let fixture: ComponentFixture<TestComponent>;
+    let hostComp: any;
+
+    beforeEach(() => {
+      const template = `<component-injector><div [ndcDynamicDirectives]="dirs"></div></component-injector>`;
+      TestBed.overrideComponent(TestComponent, { set: { template } });
+      fixture = TestBed.createComponent(TestComponent);
+      hostComp = fixture.componentInstance;
+    });
+
+    it('should init directives', () => {
+      hostComp.dirs = [dynamicDirectiveDef(MockDirective), dynamicDirectiveDef(Mock2Directive)];
+
+      expect(MockDirective.INSTANCES.size).toBe(0);
+      fixture.detectChanges();
+      expect(MockDirective.INSTANCES.size).toBe(2);
+    });
+
+    it('should destroy all directives', () => {
+      hostComp.dirs = [dynamicDirectiveDef(MockDirective), dynamicDirectiveDef(Mock2Directive)];
+
+      fixture.detectChanges();
+      expect(MockDirective.INSTANCES.size).toBeGreaterThan(0);
+
+      fixture.destroy();
+      expect(MockDirective.INSTANCES.size).toBe(0);
+    });
+
+    it('should call static life-cycle hooks in order', () => {
+      hostComp.dirs = [dynamicDirectiveDef(MockDirective)];
+
+      fixture.detectChanges();
+
+      const dir = getFirstDir();
+
+      expect(dir.ngOnInit).toHaveBeenCalledTimes(1);
+      expect(dir.ngAfterContentInit).toHaveBeenCalledTimes(1);
+      expect(dir.ngAfterContentChecked).toHaveBeenCalledTimes(1);
+      expect(dir.ngAfterViewInit).toHaveBeenCalledTimes(1);
+      expect(dir.ngAfterViewChecked).toHaveBeenCalledTimes(1);
+
+      // Verify order
+      expect(dir.hooksOrder).toEqual([
+        'ngOnInit',
+        'ngAfterContentInit',
+        'ngAfterContentChecked',
+        'ngAfterViewInit',
+        'ngAfterViewChecked',
+      ]);
+    });
+
+    it('should not init directives of same type', () => {
+      hostComp.dirs = [
+        dynamicDirectiveDef(MockDirective),
+        dynamicDirectiveDef(MockDirective),
+        dynamicDirectiveDef(MockDirective),
+      ];
+
+      fixture.detectChanges();
+
+      expect(MockDirective.INSTANCES.size).toBe(1);
+    });
+
+    it('should init added directive', () => {
+      hostComp.dirs = [dynamicDirectiveDef(MockDirective)];
+      fixture.detectChanges();
+
+      expect(MockDirective.INSTANCES.size).toBe(1);
+
+      hostComp.dirs = [dynamicDirectiveDef(MockDirective), dynamicDirectiveDef(Mock2Directive)];
+      fixture.detectChanges();
+
+      expect(MockDirective.INSTANCES.size).toBe(2);
+    });
+
+    it('should init pushed directive', () => {
+      const dirs = [dynamicDirectiveDef(MockDirective)];
+      hostComp.dirs = dirs;
+      fixture.detectChanges();
+
+      expect(MockDirective.INSTANCES.size).toBe(1);
+
+      dirs.push(dynamicDirectiveDef(Mock2Directive));
+      fixture.detectChanges();
+
+      expect(MockDirective.INSTANCES.size).toBe(2);
+    });
+
+    it('should destroy removed directive', () => {
+      hostComp.dirs = [dynamicDirectiveDef(MockDirective), dynamicDirectiveDef(Mock2Directive)];
+      fixture.detectChanges();
+
+      expect(MockDirective.INSTANCES.size).toBe(2);
+
+      hostComp.dirs = [dynamicDirectiveDef(MockDirective)];
+      fixture.detectChanges();
+
+      expect(MockDirective.INSTANCES.size).toBe(1);
+    });
+  });
+
+  describe('@Output(ndcDynamicDirectivesCreated)', () => {
+    let fixture: ComponentFixture<TestComponent>;
+    let hostComp: any;
+    let created = jest.fn();
+
+    beforeEach(() => {
+      created.mockReset();
+      const template = `<component-injector><div
+        [ndcDynamicDirectives]="dirs"
+        (ndcDynamicDirectivesCreated)="created($event)"></div></component-injector>`;
+      TestBed.overrideComponent(TestComponent, { set: { template } });
+      fixture = TestBed.createComponent(TestComponent);
+      hostComp = fixture.componentInstance;
+      hostComp.created = created;
+    });
+
+    it('should emit with dynamic directive refs', () => {
+      hostComp.dirs = [dynamicDirectiveDef(MockDirective)];
+
+      fixture.detectChanges();
+
+      const dir = getFirstDir();
+
+      expect(dir).toBeTruthy();
+      expect(created).toHaveBeenCalledWith([
+        expect.objectContaining({
+          type: MockDirective,
+          instance: dir,
+        }),
+      ]);
+    });
+
+    it('should emit with only added directive refs', () => {
+      const dirs = [dynamicDirectiveDef(MockDirective)];
+      hostComp.dirs = dirs;
+
+      fixture.detectChanges();
+      created.mockReset();
+
+      dirs.push(dynamicDirectiveDef(Mock2Directive));
+      fixture.detectChanges();
+
+      const dir = Array.from(MockDirective.INSTANCES).pop();
+
+      expect(created).toHaveBeenCalledWith([
+        expect.objectContaining({
+          type: Mock2Directive,
+          instance: dir,
+        }),
+      ]);
+    });
+  });
+
+  describe('with `ngComponentOutlet`', () => {
+    let fixture: ComponentFixture<TestComponent>;
+    let created = jest.fn<MockDirective>();
+
+    beforeEach(() => {
+      created.mockReset();
+      const template = `<ng-container [ngComponentOutlet]="comp"
+        [ndcDynamicDirectives]="dirs"
+        (ndcDynamicDirectivesCreated)="created($event)"></ng-container>`;
+      TestBed.overrideComponent(TestComponent, { set: { template } });
+      fixture = TestBed.createComponent(TestComponent);
+      fixture.componentInstance['comp'] = InjectedComponent;
+      fixture.componentInstance['created'] = created;
+    });
+
+    it('should apply directives', () => {
+      fixture.componentInstance['dirs'] = [dynamicDirectiveDef(MockDirective)];
+
+      fixture.detectChanges();
+
+      expect(created).toHaveBeenCalled();
+
+      const dir = getCreateDirs(created);
+      expect(dir).toBeTruthy();
+    });
+  });
+
+  describe('with `*ngComponentOutlet`', () => {
+    let fixture: ComponentFixture<TestComponent>;
+    let created = jest.fn<MockDirective>();
+
+    beforeEach(() => {
+      created.mockReset();
+      const template = `<ng-container *ngComponentOutlet="comp; ndcDynamicDirectives: dirs"></ng-container>`;
+      TestBed.overrideComponent(TestComponent, { set: { template } });
+      fixture = TestBed.createComponent(TestComponent);
+      fixture.componentInstance['comp'] = InjectedComponent;
+      fixture.componentInstance['created'] = created;
+    });
+
+    it('should apply directives', () => {
+      fixture.componentInstance['dirs'] = [dynamicDirectiveDef(MockDirective)];
+
+      fixture.detectChanges();
+
+      // @Output(ndcDynamicDirectivesCreated) cannot be used with `*` syntax!
+      expect(MockDirective.INSTANCES.size).toBe(1);
+    });
+  });
+
+  describe('injector', () => {
+    let fixture: ComponentFixture<TestComponent>;
+    let created = jest.fn<any>();
+
+    beforeEach(() => {
+      created.mockReset();
+      const template = `<ng-container [ngComponentOutlet]="comp"
+        [ndcDynamicDirectives]="dirs"
+        (ndcDynamicDirectivesCreated)="created($event)"></ng-container>`;
+      TestBed.overrideComponent(TestComponent, { set: { template } });
+      fixture = TestBed.createComponent(TestComponent);
+      fixture.componentInstance['comp'] = InjectedComponent;
+      fixture.componentInstance['created'] = created;
+    });
+
+    it('should be able to inject `ElementRef`', () => {
+      @Directive({ selector: 'mock' })
+      class TestDirective {
+        constructor(public elem: ElementRef) {}
+      }
+      fixture.componentInstance['dirs'] = [dynamicDirectiveDef(TestDirective)];
+
+      fixture.detectChanges();
+
+      const [{ instance }] = getCreateDirs<TestDirective>(created);
+
+      expect(instance).toBeTruthy();
+      expect(instance.elem).toEqual(expect.any(ElementRef));
+    });
+
+    it('should be able to inject `ChangeDetectorRef`', () => {
+      @Directive({ selector: 'mock' })
+      class TestDirective {
+        constructor(public cdr: ChangeDetectorRef) {}
+      }
+      fixture.componentInstance['dirs'] = [dynamicDirectiveDef(TestDirective)];
+
+      fixture.detectChanges();
+
+      const [{ instance }] = getCreateDirs<TestDirective>(created);
+
+      expect(instance).toBeTruthy();
+      expect(instance.cdr).toEqual(expect.objectContaining(ChangeDetectorRef.prototype));
+    });
+
+    it('should be able to inject `ViewContainerRef`', () => {
+      @Directive({ selector: 'mock' })
+      class TestDirective {
+        constructor(public vcr: ViewContainerRef) {}
+      }
+      fixture.componentInstance['dirs'] = [dynamicDirectiveDef(TestDirective)];
+
+      fixture.detectChanges();
+
+      const [{ instance }] = getCreateDirs<TestDirective>(created);
+
+      expect(instance).toBeTruthy();
+      expect(instance.vcr).toEqual(expect.objectContaining(ViewContainerRef.prototype));
+    });
+  });
+
+  describe('directive inputs', () => {
+    let fixture: ComponentFixture<TestComponent>;
+    let created = jest.fn<MockDirective>();
+    let hostComp: any;
+
+    beforeEach(() => {
+      created.mockReset();
+      const template = `<ng-container [ngComponentOutlet]="comp"
+        [ndcDynamicDirectives]="dirs"
+        (ndcDynamicDirectivesCreated)="created($event)"></ng-container>`;
+      TestBed.overrideComponent(TestComponent, { set: { template } });
+      fixture = TestBed.createComponent(TestComponent);
+      hostComp = fixture.componentInstance;
+      hostComp.comp = InjectedComponent;
+      hostComp.created = created;
+    });
+
+    it('should set inputs on directive instance', () => {
+      hostComp.dirs = [
+        dynamicDirectiveDef(MockDirective, { in: 'in' }),
+        dynamicDirectiveDef(Mock2Directive, { in2: 'in2' }),
+      ];
+
+      fixture.detectChanges();
+
+      const [dir1, dir2] = getCreateDirs(created);
+
+      expect(dir1.instance.in).toBe('in');
+      expect(dir2.instance.in2).toBe('in2');
+    });
+
+    it('should call `OnChanges` hook with initial changes', () => {
+      hostComp.dirs = [
+        dynamicDirectiveDef(MockDirective, { in: 'val' }),
+        dynamicDirectiveDef(Mock2Directive, { in2: 'val2' }),
+      ];
+
+      fixture.detectChanges();
+
+      const [dir1, dir2] = getCreateDirs(created);
+
+      expect(dir1.instance.ngOnChanges).toHaveBeenCalledWith({
+        in: new SimpleChange(undefined, 'val', true),
+      });
+      expect(dir2.instance.ngOnChanges).toHaveBeenCalledWith({
+        in2: new SimpleChange(undefined, 'val2', true),
+      });
+    });
+
+    it('should call `OnChanges` when inputs change', () => {
+      const inputs1 = { in: 'val' };
+      const inputs2 = { in2: 'val2' };
+      hostComp.dirs = [
+        dynamicDirectiveDef(MockDirective, inputs1),
+        dynamicDirectiveDef(Mock2Directive, inputs2),
+      ];
+
+      fixture.detectChanges();
+
+      const [dir1, dir2] = getCreateDirs(created);
+
+      dir1.instance.ngOnChanges.mockReset();
+      dir2.instance.ngOnChanges.mockReset();
+
+      inputs1.in = 'new-val';
+      fixture.detectChanges();
+
+      expect(dir1.instance.ngOnChanges).toHaveBeenCalledWith({
+        in: new SimpleChange('val', 'new-val', false),
+      });
+      expect(dir2.instance.ngOnChanges).not.toHaveBeenCalled();
+
+      dir1.instance.ngOnChanges.mockReset();
+      dir2.instance.ngOnChanges.mockReset();
+
+      inputs2.in2 = 'new-val2';
+      fixture.detectChanges();
+
+      expect(dir1.instance.ngOnChanges).not.toHaveBeenCalled();
+      expect(dir2.instance.ngOnChanges).toHaveBeenCalledWith({
+        in2: new SimpleChange('val2', 'new-val2', false),
+      });
+    });
+
+    it('should call `OnChanges` when inputs replaced', () => {
+      const dirDef1 = dynamicDirectiveDef(MockDirective, { in: 'val' });
+      const dirDef2 = dynamicDirectiveDef(Mock2Directive, { in2: 'val2' });
+      hostComp.dirs = [dirDef1, dirDef2];
+
+      fixture.detectChanges();
+
+      const [dir1, dir2] = getCreateDirs(created);
+
+      dir1.instance.ngOnChanges.mockReset();
+      dir2.instance.ngOnChanges.mockReset();
+
+      dirDef1.inputs = { in: 'new-val' };
+      fixture.detectChanges();
+
+      expect(dir1.instance.ngOnChanges).toHaveBeenCalledWith({
+        in: new SimpleChange('val', 'new-val', false),
+      });
+      expect(dir2.instance.ngOnChanges).not.toHaveBeenCalled();
+
+      dir1.instance.ngOnChanges.mockReset();
+      dir2.instance.ngOnChanges.mockReset();
+
+      dirDef2.inputs = { in2: 'new-val2' };
+      fixture.detectChanges();
+
+      expect(dir1.instance.ngOnChanges).not.toHaveBeenCalled();
+      expect(dir2.instance.ngOnChanges).toHaveBeenCalledWith({
+        in2: new SimpleChange('val2', 'new-val2', false),
+      });
+    });
+  });
+
+  describe('directive outputs', () => {
+    let fixture: ComponentFixture<TestComponent>;
+    let created = jest.fn<MockDirective>();
+    let hostComp: any;
+
+    beforeEach(() => {
+      created.mockReset();
+      const template = `<ng-container [ngComponentOutlet]="comp"
+        [ndcDynamicDirectives]="dirs"
+        (ndcDynamicDirectivesCreated)="created($event)"></ng-container>`;
+      TestBed.overrideComponent(TestComponent, { set: { template } });
+      fixture = TestBed.createComponent(TestComponent);
+      hostComp = fixture.componentInstance;
+      hostComp.comp = InjectedComponent;
+      hostComp.created = created;
+    });
+
+    it('should be connected', () => {
+      const callback1 = jest.fn();
+      const callback2 = jest.fn();
+      hostComp.dirs = [
+        dynamicDirectiveDef(MockDirective, null, { out: callback1 }),
+        dynamicDirectiveDef(Mock2Directive, null, { out: callback2 }),
+      ];
+
+      fixture.detectChanges();
+
+      const [dir1, dir2] = getCreateDirs(created);
+
+      dir1.instance.out.next('data');
+      dir2.instance.out.next('data2');
+
+      expect(callback1).toHaveBeenCalledWith('data');
+      expect(callback2).toHaveBeenCalledWith('data2');
+    });
+
+    it('should be connected when changed and disconnected from old', () => {
+      const callback = jest.fn();
+      const outputs = { out: callback };
+      hostComp.dirs = [dynamicDirectiveDef(MockDirective, null, outputs)];
+
+      fixture.detectChanges();
+
+      const [{ instance }] = getCreateDirs(created);
+
+      const callback2 = jest.fn();
+      outputs.out = callback2;
+
+      fixture.detectChanges();
+
+      instance.out.next('data');
+
+      expect(callback2).toHaveBeenCalledWith('data');
+      expect(callback).not.toHaveBeenCalledWith('data');
+    });
+
+    it('should disconnect when removed', () => {
+      const callback = jest.fn();
+      const outputs = { out: callback };
+      hostComp.dirs = [dynamicDirectiveDef(MockDirective, null, outputs)];
+
+      fixture.detectChanges();
+
+      const [{ instance }] = getCreateDirs(created);
+
+      outputs.out = undefined;
+      fixture.detectChanges();
+
+      instance.out.next('data');
+
+      expect(callback).not.toHaveBeenCalled();
+    });
+
+    it('should disconnect when host component destroyed', () => {
+      const callback = jest.fn();
+      hostComp.dirs = [dynamicDirectiveDef(MockDirective, null, { out: callback })];
+
+      fixture.detectChanges();
+
+      const [{ instance }] = getCreateDirs(created);
+
+      fixture.destroy();
+
+      instance.out.next('data');
+
+      expect(callback).not.toHaveBeenCalled();
+    });
+  });
+});
+
+function getFirstDir() {
+  return getFirstFrom(MockDirective.INSTANCES);
+}
+
+function getFirstFrom<T>(set: Set<T>): T {
+  return set.values().next().value;
+}
+
+function getCreateDirs<T>(mockFn: jest.Mock<T>): DirectiveRef<T>[] {
+  return mockFn.mock.calls[0][0];
+}

--- a/src/dynamic/dynamic-directives.directive.ts
+++ b/src/dynamic/dynamic-directives.directive.ts
@@ -11,10 +11,8 @@ import {
   Input,
   IterableDiffers,
   OnDestroy,
-  OnInit,
   Optional,
   Output,
-  SimpleChanges,
   Type,
   ViewContainerRef,
   ViewRef,
@@ -54,7 +52,7 @@ export interface DirectiveRef<T> {
 @Directive({
   selector: '[ndcDynamicDirectives],[ngComponentOutletNdcDynamicDirectives]',
 })
-export class DynamicDirectivesDirective implements OnInit, OnDestroy, DoCheck {
+export class DynamicDirectivesDirective implements OnDestroy, DoCheck {
   @Input()
   ndcDynamicDirectives: DynamicDirectiveDef<any>[];
   @Input()
@@ -106,12 +104,6 @@ export class DynamicDirectivesDirective implements OnInit, OnDestroy, DoCheck {
     @Optional()
     private componentOutletInjector: ComponentOutletInjectorDirective,
   ) {}
-
-  ngOnInit(): void {
-    if (!this.componentRef) {
-      throw Error('DynamicDirectivesDirective: ComponentRef not available!');
-    }
-  }
 
   ngDoCheck(): void {
     this.checkDirectives();
@@ -181,10 +173,6 @@ export class DynamicDirectivesDirective implements OnInit, OnDestroy, DoCheck {
   }
 
   private destroyDirective(dirDef: DynamicDirectiveDef<any>) {
-    if (!this.dirRef.has(dirDef.type)) {
-      return;
-    }
-
     this.destroyDirRef(this.dirRef.get(dirDef.type));
     this.dirRef.delete(dirDef.type);
     this.dirIo.delete(dirDef.type);

--- a/src/dynamic/dynamic-directives.directive.ts
+++ b/src/dynamic/dynamic-directives.directive.ts
@@ -90,9 +90,6 @@ export class DynamicDirectivesDirective implements OnInit, OnDestroy, DoCheck {
   private dirsDiffer = this.iterableDiffers
     .find([])
     .create<DynamicDirectiveDef<any>>((_, def) => def.type);
-  private inputsDiffer = this.iterableDiffers
-    .find([])
-    .create<DynamicDirectiveDef<any>>((_, def) => def.inputs);
 
   constructor(
     private injector: Injector,

--- a/src/dynamic/dynamic-directives.directive.ts
+++ b/src/dynamic/dynamic-directives.directive.ts
@@ -1,0 +1,241 @@
+import {
+  ChangeDetectorRef,
+  ComponentRef,
+  Directive,
+  DoCheck,
+  ElementRef,
+  EventEmitter,
+  Host,
+  Inject,
+  Injector,
+  Input,
+  IterableDiffers,
+  OnDestroy,
+  OnInit,
+  Optional,
+  Output,
+  SimpleChanges,
+  Type,
+  ViewContainerRef,
+  ViewRef,
+} from '@angular/core';
+
+import { COMPONENT_INJECTOR, ComponentInjector } from './component-injector';
+import { ComponentOutletInjectorDirective } from './component-outlet-injector.directive';
+import { IoFactoryService } from './io-factory.service';
+import { InputsType, IoService, OutputsType } from './io.service';
+import { getCtorType } from './util';
+
+export interface DynamicDirectiveDef<T> {
+  type: Type<T>;
+  inputs?: InputsType;
+  outputs?: OutputsType;
+}
+
+export function dynamicDirectiveDef<T>(
+  type: Type<T>,
+  inputs?: InputsType,
+  outputs?: OutputsType,
+): DynamicDirectiveDef<T> {
+  return { type, inputs, outputs };
+}
+
+export interface DirectiveRef<T> {
+  instance: T;
+  type: Type<T>;
+  injector: Injector;
+  hostComponent: Type<any>;
+  hostView: ViewRef;
+  location: ElementRef;
+  changeDetectorRef: ChangeDetectorRef;
+  onDestroy: (callback: Function) => void;
+}
+
+@Directive({
+  selector: '[ndcDynamicDirectives],[ngComponentOutletNdcDynamicDirectives]',
+})
+export class DynamicDirectivesDirective implements OnInit, OnDestroy, DoCheck {
+  @Input() ndcDynamicDirectives: DynamicDirectiveDef<any>[];
+  @Input() ngComponentOutletNdcDynamicDirectives: DynamicDirectiveDef<any>[];
+
+  @Output() ndcDynamicDirectivesCreated = new EventEmitter<DirectiveRef<any>[]>();
+
+  private componentInjector: ComponentInjector = this.injector.get(
+    this.componentInjectorType,
+    null,
+  );
+
+  private get directives() {
+    return this.ndcDynamicDirectives || this.ngComponentOutletNdcDynamicDirectives;
+  }
+
+  private get compInjector() {
+    return this.componentOutletInjector || this.componentInjector;
+  }
+
+  private get componentRef() {
+    return this.compInjector.componentRef;
+  }
+
+  private get hostInjector() {
+    return this.componentRef.injector;
+  }
+
+  private get hostVcr(): ViewContainerRef {
+    return this.componentRef['_viewRef']['_viewContainerRef'];
+  }
+
+  private dirRef = new Map<Type<any>, DirectiveRef<any>>();
+  private dirIo = new Map<Type<any>, IoService>();
+  private dirsDiffer = this.iterableDiffers
+    .find([])
+    .create<DynamicDirectiveDef<any>>((_, def) => def.type);
+  private inputsDiffer = this.iterableDiffers
+    .find([])
+    .create<DynamicDirectiveDef<any>>((_, def) => def.inputs);
+
+  constructor(
+    private injector: Injector,
+    private iterableDiffers: IterableDiffers,
+    private ioFactoryService: IoFactoryService,
+    @Inject(COMPONENT_INJECTOR) private componentInjectorType: ComponentInjector,
+    @Host()
+    @Optional()
+    private componentOutletInjector: ComponentOutletInjectorDirective,
+  ) {}
+
+  ngOnInit(): void {
+    if (!this.componentRef) {
+      throw Error('DynamicDirectivesDirective: ComponentRef not available!');
+    }
+  }
+
+  ngDoCheck(): void {
+    this.checkDirectives();
+  }
+
+  ngOnDestroy(): void {
+    this.dirRef.forEach((dir) => this.destroyDirRef(dir));
+    this.dirRef.clear();
+    this.dirIo.clear();
+  }
+
+  private checkDirectives() {
+    const dirsChanges = this.dirsDiffer.diff(this.directives);
+
+    if (!dirsChanges) {
+      return this.updateDirectives();
+    }
+
+    dirsChanges.forEachRemovedItem(({ item }) => this.destroyDirective(item));
+
+    const createdDirs = [];
+
+    dirsChanges.forEachAddedItem(({ item }) => createdDirs.push(this.initDirective(item)));
+
+    if (createdDirs.length) {
+      this.ndcDynamicDirectivesCreated.emit(createdDirs.filter(Boolean));
+    }
+  }
+
+  private updateDirectives() {
+    this.directives.forEach((dir) => this.updateDirective(dir));
+  }
+
+  private updateDirective(dirDef: DynamicDirectiveDef<any>) {
+    const io = this.dirIo.get(dirDef.type);
+    io.update(dirDef.inputs, dirDef.outputs, false, false);
+    io.maybeUpdate();
+  }
+
+  private initDirective(dirDef: DynamicDirectiveDef<any>): DirectiveRef<any> | undefined {
+    if (this.dirRef.has(dirDef.type)) {
+      return;
+    }
+
+    const instance = this.createDirective(dirDef.type);
+    const dir = {
+      instance,
+      type: dirDef.type,
+      injector: this.hostInjector,
+      hostComponent: this.componentRef.instance,
+      hostView: this.componentRef.hostView,
+      location: this.componentRef.location,
+      changeDetectorRef: this.componentRef.changeDetectorRef,
+      onDestroy: this.componentRef.onDestroy,
+    };
+
+    this.callInitHooks(instance);
+    this.initDirIO(dir, dirDef.inputs, dirDef.outputs);
+
+    this.dirRef.set(dir.type, dir);
+
+    return dir;
+  }
+
+  private destroyDirective(dirDef: DynamicDirectiveDef<any>) {
+    if (!this.dirRef.has(dirDef.type)) {
+      return;
+    }
+
+    this.destroyDirRef(this.dirRef.get(dirDef.type));
+    this.dirRef.delete(dirDef.type);
+    this.dirIo.delete(dirDef.type);
+  }
+
+  private initDirIO(dir: DirectiveRef<any>, inputs?: any, outputs?: any) {
+    const io = this.ioFactoryService.create();
+    io.init({ componentRef: this.dirToCompDef(dir) }, { trackOutputChanges: true });
+    io.update(inputs, outputs, !!inputs, !!outputs);
+    this.dirIo.set(dir.type, io);
+  }
+
+  private dirToCompDef(dir: DirectiveRef<any>): ComponentRef<any> {
+    return {
+      ...this.componentRef,
+      destroy: this.componentRef.destroy,
+      onDestroy: this.componentRef.onDestroy,
+      instance: dir.instance,
+      componentType: dir.type,
+    };
+  }
+
+  private destroyDirRef(dir: DirectiveRef<any>) {
+    const io = this.dirIo.get(dir.type);
+    io.ngOnDestroy();
+
+    if ('ngOnDestroy' in dir.instance) {
+      dir.instance.ngOnDestroy();
+    }
+  }
+
+  private createDirective<T>(dirType: Type<T>): T {
+    const ctorParams: any[] = getCtorType(dirType);
+    const resolvedParams = ctorParams.map((p) => this.resolveDep(p));
+    return new dirType(...resolvedParams);
+  }
+
+  private resolveDep(dep: any): any {
+    return this.maybeResolveVCR(dep) || this.hostInjector.get(dep);
+  }
+
+  private maybeResolveVCR(dep: any): ViewContainerRef | undefined {
+    if (dep === ViewContainerRef) {
+      return this.hostVcr;
+    }
+  }
+
+  private callInitHooks(obj: any) {
+    this.callHook(obj, 'ngOnInit');
+    this.callHook(obj, 'ngAfterContentInit');
+    this.callHook(obj, 'ngAfterContentChecked');
+    this.callHook(obj, 'ngAfterViewInit');
+    this.callHook(obj, 'ngAfterViewChecked');
+  }
+
+  private callHook(obj: any, hook: string, args: any[] = []) {
+    if (obj[hook]) {
+      obj[hook](...args);
+    }
+  }
+}

--- a/src/dynamic/dynamic.directive.ts
+++ b/src/dynamic/dynamic.directive.ts
@@ -1,52 +1,34 @@
 import {
-  ComponentFactory,
-  ComponentFactoryResolver,
   Directive,
   DoCheck,
   Host,
   Inject,
   Injector,
   Input,
-  KeyValueChanges,
-  KeyValueDiffers,
   OnChanges,
-  OnDestroy,
   Optional,
   SimpleChanges,
 } from '@angular/core';
-import { takeUntil } from 'rxjs/operators';
-import { Subject } from 'rxjs';
 
 import { COMPONENT_INJECTOR, ComponentInjector } from './component-injector';
 import { ComponentOutletInjectorDirective } from './component-outlet-injector.directive';
-import { changesFromRecord, createNewChange } from './util';
-
-export type IOMapInfo = { propName: string; templateName: string };
-export type IOMappingList = IOMapInfo[];
-export type KeyValueChangesAny = KeyValueChanges<any, any>;
-
-const recordToChanges = changesFromRecord({ isFirstChanges: true });
-const recordToNewChanges = changesFromRecord({ onlyNewChanges: true });
+import { InputsType, IoService, OutputsType } from './io.service';
 
 @Directive({
   selector:
     '[ndcDynamicInputs],[ndcDynamicOutputs],[ngComponentOutletNdcDynamicInputs],[ngComponentOutletNdcDynamicOutputs]',
+  providers: [IoService],
 })
-export class DynamicDirective implements OnChanges, DoCheck, OnDestroy {
-  @Input() ndcDynamicInputs: { [k: string]: any };
-  @Input() ngComponentOutletNdcDynamicInputs: { [k: string]: any };
-  @Input() ndcDynamicOutputs: { [k: string]: Function };
-  @Input() ngComponentOutletNdcDynamicOutputs: { [k: string]: Function };
+export class DynamicDirective implements OnChanges, DoCheck {
+  @Input() ndcDynamicInputs: InputsType;
+  @Input() ngComponentOutletNdcDynamicInputs: InputsType;
+  @Input() ndcDynamicOutputs: OutputsType;
+  @Input() ngComponentOutletNdcDynamicOutputs: OutputsType;
 
   private _componentInjector: ComponentInjector = this._injector.get(
     this._componentInjectorType,
     null,
   );
-  private _lastComponentInst: any = this._componentInjector;
-  private _lastInputChanges: SimpleChanges;
-  private _inputsDiffer = this._differs.find({}).create();
-  private _compFactory: ComponentFactory<any> | null = null;
-  private _outputsShouldDisconnect$ = new Subject<void>();
 
   private get _inputs() {
     return this.ndcDynamicInputs || this.ngComponentOutletNdcDynamicInputs;
@@ -60,247 +42,35 @@ export class DynamicDirective implements OnChanges, DoCheck, OnDestroy {
     return this._componentOutletInjector || this._componentInjector;
   }
 
-  private get _compRef() {
-    return this._compInjector.componentRef;
-  }
-
-  private get _componentInst() {
-    return this._compRef.instance;
-  }
-
-  private get _componentInstChanged(): boolean {
-    if (this._lastComponentInst !== this._componentInst) {
-      this._lastComponentInst = this._componentInst;
-      return true;
-    } else {
-      return false;
-    }
-  }
-
   constructor(
-    private _differs: KeyValueDiffers,
     private _injector: Injector,
-    private _cfr: ComponentFactoryResolver,
-    @Inject(COMPONENT_INJECTOR)
-    private _componentInjectorType: ComponentInjector,
+    private ioService: IoService,
+    @Inject(COMPONENT_INJECTOR) private _componentInjectorType: ComponentInjector,
     @Host()
     @Optional()
     private _componentOutletInjector: ComponentOutletInjectorDirective,
-  ) {}
+  ) {
+    this.ioService.init(this._compInjector);
+  }
 
   ngOnChanges(changes: SimpleChanges) {
-    const compChanged = this._componentInstChanged;
-
-    if (compChanged || this._inputsChanged(changes)) {
-      const inputsChanges = this._getInputsChanges(this._inputs);
-
-      if (inputsChanges) {
-        this._updateInputChanges(inputsChanges);
-      }
-
-      this.updateInputs(compChanged || !this._lastInputChanges);
-    }
-
-    if (compChanged || this._outputsChanged(changes)) {
-      this.bindOutputs();
-    }
+    this.ioService.update(
+      this._inputs,
+      this._outputs,
+      this._inputsChanged(changes),
+      this._outputsChanged(changes),
+    );
   }
 
   ngDoCheck() {
-    if (this._componentInstChanged) {
-      this.updateInputs(true);
-      this.bindOutputs();
-      return;
-    }
-
-    const inputs = this._inputs;
-
-    if (!inputs) {
-      return;
-    }
-
-    const inputsChanges = this._getInputsChanges(this._inputs);
-
-    if (inputsChanges) {
-      const isNotFirstChange = !!this._lastInputChanges;
-      this._updateInputChanges(inputsChanges);
-
-      if (isNotFirstChange) {
-        this.updateInputs();
-      }
-    }
-  }
-
-  ngOnDestroy() {
-    this._disconnectOutputs();
-  }
-
-  updateInputs(isFirstChange = false) {
-    if (isFirstChange) {
-      this._updateCompFactory();
-    }
-
-    const compInst = this._componentInst;
-    let inputs = this._inputs;
-
-    if (!inputs || !compInst) {
-      return;
-    }
-
-    inputs = this._resolveInputs(inputs);
-
-    Object.keys(inputs).forEach(p => (compInst[p] = inputs[p]));
-
-    this.notifyOnInputChanges(this._lastInputChanges, isFirstChange);
-  }
-
-  bindOutputs() {
-    this._disconnectOutputs();
-
-    const compInst = this._componentInst;
-    let outputs = this._outputs;
-
-    if (!outputs || !compInst) {
-      return;
-    }
-
-    outputs = this._resolveOutputs(outputs);
-
-    Object.keys(outputs)
-      .filter(p => compInst[p])
-      .forEach(p =>
-        compInst[p]
-          .pipe(takeUntil(this._outputsShouldDisconnect$))
-          .subscribe(outputs[p]),
-      );
-  }
-
-  notifyOnInputChanges(
-    changes: SimpleChanges = {},
-    forceFirstChanges: boolean,
-  ) {
-    // Exit early if component not interested to receive changes
-    if (!this._componentInst.ngOnChanges) {
-      return;
-    }
-
-    if (forceFirstChanges) {
-      changes = this._collectFirstChanges();
-    }
-
-    this._componentInst.ngOnChanges(changes);
-  }
-
-  private _disconnectOutputs() {
-    this._outputsShouldDisconnect$.next();
-  }
-
-  private _getInputsChanges(inputs: any): KeyValueChangesAny {
-    return this._inputsDiffer.diff(this._inputs);
-  }
-
-  private _updateInputChanges(differ: KeyValueChangesAny) {
-    this._lastInputChanges = this._collectChangesFromDiffer(differ);
-  }
-
-  private _collectFirstChanges(): SimpleChanges {
-    const changes = {} as SimpleChanges;
-    const inputs = this._inputs;
-
-    Object.keys(inputs).forEach(
-      prop => (changes[prop] = createNewChange(inputs[prop])),
-    );
-
-    return this._resolveChanges(changes);
-  }
-
-  private _collectChangesFromDiffer(differ: KeyValueChangesAny): SimpleChanges {
-    const changes = {} as SimpleChanges;
-
-    differ.forEachAddedItem(recordToChanges(changes));
-    differ.forEachItem(recordToNewChanges(changes));
-
-    return this._resolveChanges(changes);
+    this.ioService.maybeUpdate();
   }
 
   private _inputsChanged(changes: SimpleChanges): boolean {
-    return (
-      'ngComponentOutletNdcDynamicInputs' in changes ||
-      'ndcDynamicInputs' in changes
-    );
+    return 'ngComponentOutletNdcDynamicInputs' in changes || 'ndcDynamicInputs' in changes;
   }
 
   private _outputsChanged(changes: SimpleChanges): boolean {
-    return (
-      'ngComponentOutletNdcDynamicOutputs' in changes ||
-      'ndcDynamicOutputs' in changes
-    );
-  }
-
-  private _resolveCompFactory(): ComponentFactory<any> | null {
-    try {
-      try {
-        return this._cfr.resolveComponentFactory(this._compRef.componentType);
-      } catch (e) {
-        // Fallback if componentType does not exist (happens on NgComponentOutlet)
-        return this._cfr.resolveComponentFactory(
-          this._compRef.instance.constructor,
-        );
-      }
-    } catch (e) {
-      // Factory not available - bailout
-      return null;
-    }
-  }
-
-  private _updateCompFactory() {
-    this._compFactory = this._resolveCompFactory();
-  }
-
-  private _resolveInputs(inputs: any): any {
-    if (!this._compFactory) {
-      return inputs;
-    }
-
-    return this._remapIO(inputs, this._compFactory.inputs);
-  }
-
-  private _resolveOutputs(outputs: any): any {
-    if (!this._compFactory) {
-      return outputs;
-    }
-
-    return this._remapIO(outputs, this._compFactory.outputs);
-  }
-
-  private _resolveChanges(changes: SimpleChanges): SimpleChanges {
-    if (!this._compFactory) {
-      return changes;
-    }
-
-    return this._remapIO(changes, this._compFactory.inputs);
-  }
-
-  private _remapIO(io: any, mapping: IOMappingList): any {
-    const newIO = {};
-
-    Object.keys(io).forEach(key => {
-      const newKey = this._findPropByTplInMapping(key, mapping) || key;
-      newIO[newKey] = io[key];
-    });
-
-    return newIO;
-  }
-
-  private _findPropByTplInMapping(
-    tplName: string,
-    mapping: IOMappingList,
-  ): string | null {
-    for (const map of mapping) {
-      if (map.templateName === tplName) {
-        return map.propName;
-      }
-    }
-    return null;
+    return 'ngComponentOutletNdcDynamicOutputs' in changes || 'ndcDynamicOutputs' in changes;
   }
 }

--- a/src/dynamic/dynamic.module.ts
+++ b/src/dynamic/dynamic.module.ts
@@ -1,16 +1,13 @@
 import { CommonModule } from '@angular/common';
-import {
-  ANALYZE_FOR_ENTRY_COMPONENTS,
-  ModuleWithProviders,
-  NgModule,
-  Type,
-} from '@angular/core';
+import { ANALYZE_FOR_ENTRY_COMPONENTS, ModuleWithProviders, NgModule, Type } from '@angular/core';
 
 import { COMPONENT_INJECTOR, ComponentInjector } from './component-injector';
 import { ComponentOutletInjectorDirective } from './component-outlet-injector.directive';
 import { DynamicAttributesDirective } from './dynamic-attributes.directive';
+import { DynamicDirectivesDirective } from './dynamic-directives.directive';
 import { DynamicComponent } from './dynamic.component';
 import { DynamicDirective } from './dynamic.directive';
+import { IoFactoryService } from './io-factory.service';
 
 @NgModule({
   imports: [CommonModule],
@@ -19,12 +16,14 @@ import { DynamicDirective } from './dynamic.directive';
     DynamicDirective,
     ComponentOutletInjectorDirective,
     DynamicAttributesDirective,
+    DynamicDirectivesDirective,
   ],
   exports: [
     DynamicComponent,
     DynamicDirective,
     ComponentOutletInjectorDirective,
     DynamicAttributesDirective,
+    DynamicDirectivesDirective,
   ],
 })
 export class DynamicModule {
@@ -41,6 +40,7 @@ export class DynamicModule {
           multi: true,
         },
         { provide: COMPONENT_INJECTOR, useValue: componentInjector },
+        IoFactoryService,
       ],
     };
   }

--- a/src/dynamic/index.ts
+++ b/src/dynamic/index.ts
@@ -2,4 +2,5 @@ export * from './dynamic.module';
 export * from './dynamic.directive';
 export * from './dynamic.component';
 export * from './dynamic-attributes.directive';
+export * from './dynamic-directives.directive';
 export { ComponentInjector } from './component-injector';

--- a/src/dynamic/io-factory.service.spec.ts
+++ b/src/dynamic/io-factory.service.spec.ts
@@ -1,0 +1,16 @@
+/* tslint:disable:no-unused-variable */
+
+import { TestBed, async, inject } from '@angular/core/testing';
+import { IoFactoryService } from './io-factory.service';
+
+describe('Service: IoFactory', () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [IoFactoryService]
+    });
+  });
+
+  it('should ...', inject([IoFactoryService], (service: IoFactoryService) => {
+    expect(service).toBeTruthy();
+  }));
+});

--- a/src/dynamic/io-factory.service.ts
+++ b/src/dynamic/io-factory.service.ts
@@ -1,0 +1,12 @@
+import { ComponentFactoryResolver, Injectable, KeyValueDiffers } from '@angular/core';
+
+import { IoService } from './io.service';
+
+@Injectable()
+export class IoFactoryService {
+  constructor(private differs: KeyValueDiffers, private cfr: ComponentFactoryResolver) {}
+
+  create() {
+    return new IoService(this.differs, this.cfr);
+  }
+}

--- a/src/dynamic/io.service.spec.ts
+++ b/src/dynamic/io.service.spec.ts
@@ -1,0 +1,16 @@
+/* tslint:disable:no-unused-variable */
+
+import { TestBed, async, inject } from '@angular/core/testing';
+import { IoService } from './io.service';
+
+describe('Service: Io', () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [IoService]
+    });
+  });
+
+  it('should ...', inject([IoService], (service: IoService) => {
+    expect(service).toBeTruthy();
+  }));
+});

--- a/src/dynamic/io.service.spec.ts
+++ b/src/dynamic/io.service.spec.ts
@@ -4,13 +4,21 @@ import { TestBed, async, inject } from '@angular/core/testing';
 import { IoService } from './io.service';
 
 describe('Service: Io', () => {
+  let service: IoService;
+
   beforeEach(() => {
     TestBed.configureTestingModule({
       providers: [IoService],
     });
+    service = TestBed.get(IoService);
   });
 
-  it('should ...', inject([IoService], (service: IoService) => {
-    expect(service).toBeTruthy();
-  }));
+  it('should throw if init was not called', () => {
+    expect(() => service.maybeUpdate()).toThrow();
+  });
+
+  it('should throw if `ComponentInjector` is set to null', () => {
+    service.init(null);
+    expect(() => service.maybeUpdate()).toThrow();
+  });
 });

--- a/src/dynamic/io.service.ts
+++ b/src/dynamic/io.service.ts
@@ -1,0 +1,262 @@
+import {
+  ComponentFactory,
+  ComponentFactoryResolver,
+  Injectable,
+  KeyValueChanges,
+  KeyValueDiffers,
+  SimpleChanges,
+} from '@angular/core';
+import { Subject } from 'rxjs';
+import { takeUntil } from 'rxjs/operators';
+
+import { ComponentInjector } from './component-injector';
+import { changesFromRecord, createNewChange, noop } from './util';
+
+export type InputsType = { [k: string]: any };
+export type OutputsType = { [k: string]: Function };
+export type IOMapInfo = { propName: string; templateName: string };
+export type IOMappingList = IOMapInfo[];
+export type KeyValueChangesAny = KeyValueChanges<any, any>;
+
+const recordToChanges = changesFromRecord({ isFirstChanges: true });
+const recordToNewChanges = changesFromRecord({ onlyNewChanges: true });
+
+@Injectable()
+export class IoService {
+  private checkInit = this.failInit;
+
+  private _lastComponentInst: any = null;
+  private _lastInputChanges: SimpleChanges;
+  private _inputsDiffer = this._differs.find({}).create();
+  private _compFactory: ComponentFactory<any> | null = null;
+  private _outputsShouldDisconnect$ = new Subject<void>();
+
+  private _inputs: InputsType;
+  private _outputs: OutputsType;
+  private _compInjector: ComponentInjector;
+
+  private get _compRef() {
+    return this._compInjector.componentRef;
+  }
+
+  private get _componentInst() {
+    return this._compRef.instance;
+  }
+
+  private get _componentInstChanged(): boolean {
+    if (this._lastComponentInst !== this._componentInst) {
+      this._lastComponentInst = this._componentInst;
+      return true;
+    } else {
+      return false;
+    }
+  }
+
+  constructor(private _differs: KeyValueDiffers, private _cfr: ComponentFactoryResolver) {}
+
+  init(componentInjector: ComponentInjector) {
+    this.checkInit = componentInjector ? noop : this.failInit;
+    this._compInjector = componentInjector;
+  }
+
+  update(
+    inputs: InputsType,
+    outputs: OutputsType,
+    inputsChanged: boolean,
+    outputsChanged: boolean,
+  ) {
+    this.checkInit();
+    this.updateIO(inputs, outputs);
+
+    const compChanged = this._componentInstChanged;
+
+    if (compChanged || inputsChanged) {
+      const inputsChanges = this._getInputsChanges(this._inputs);
+      if (inputsChanges) {
+        this._updateInputChanges(inputsChanges);
+      }
+      this.updateInputs(compChanged || !this._lastInputChanges);
+    }
+
+    if (compChanged || outputsChanged) {
+      this.bindOutputs();
+    }
+  }
+
+  maybeUpdate() {
+    this.checkInit();
+
+    if (this._componentInstChanged) {
+      this.updateInputs(true);
+      this.bindOutputs();
+      return;
+    }
+
+    if (!this._inputs) {
+      return;
+    }
+
+    const inputsChanges = this._getInputsChanges(this._inputs);
+
+    if (inputsChanges) {
+      const isNotFirstChange = !!this._lastInputChanges;
+      this._updateInputChanges(inputsChanges);
+
+      if (isNotFirstChange) {
+        this.updateInputs();
+      }
+    }
+  }
+
+  private updateIO(inputs: InputsType, outputs: OutputsType) {
+    this._inputs = inputs;
+    this._outputs = outputs;
+  }
+
+  private updateInputs(isFirstChange = false) {
+    if (isFirstChange) {
+      this._updateCompFactory();
+    }
+
+    const compInst = this._componentInst;
+    let inputs = this._inputs;
+
+    if (!inputs || !compInst) {
+      return;
+    }
+
+    inputs = this._resolveInputs(inputs);
+
+    Object.keys(inputs).forEach((p) => (compInst[p] = inputs[p]));
+
+    this.notifyOnInputChanges(this._lastInputChanges, isFirstChange);
+  }
+
+  private bindOutputs() {
+    this._disconnectOutputs();
+
+    const compInst = this._componentInst;
+    let outputs = this._outputs;
+
+    if (!outputs || !compInst) {
+      return;
+    }
+
+    outputs = this._resolveOutputs(outputs);
+
+    Object.keys(outputs)
+      .filter((p) => compInst[p])
+      .forEach((p) =>
+        compInst[p].pipe(takeUntil(this._outputsShouldDisconnect$)).subscribe(outputs[p]),
+      );
+  }
+
+  private notifyOnInputChanges(changes: SimpleChanges = {}, forceFirstChanges: boolean) {
+    // Exit early if component not interested to receive changes
+    if (!this._componentInst.ngOnChanges) {
+      return;
+    }
+
+    if (forceFirstChanges) {
+      changes = this._collectFirstChanges();
+    }
+
+    this._componentInst.ngOnChanges(changes);
+  }
+
+  private _disconnectOutputs() {
+    this._outputsShouldDisconnect$.next();
+  }
+
+  private _getInputsChanges(inputs: any): KeyValueChangesAny {
+    return this._inputsDiffer.diff(this._inputs);
+  }
+
+  private _updateInputChanges(differ: KeyValueChangesAny) {
+    this._lastInputChanges = this._collectChangesFromDiffer(differ);
+  }
+
+  private _collectFirstChanges(): SimpleChanges {
+    const changes = {} as SimpleChanges;
+    const inputs = this._inputs;
+
+    Object.keys(inputs).forEach((prop) => (changes[prop] = createNewChange(inputs[prop])));
+
+    return this._resolveChanges(changes);
+  }
+
+  private _collectChangesFromDiffer(differ: KeyValueChangesAny): SimpleChanges {
+    const changes = {} as SimpleChanges;
+
+    differ.forEachAddedItem(recordToChanges(changes));
+    differ.forEachItem(recordToNewChanges(changes));
+
+    return this._resolveChanges(changes);
+  }
+
+  private _resolveCompFactory(): ComponentFactory<any> | null {
+    try {
+      try {
+        return this._cfr.resolveComponentFactory(this._compRef.componentType);
+      } catch (e) {
+        // Fallback if componentType does not exist (happens on NgComponentOutlet)
+        return this._cfr.resolveComponentFactory(this._compRef.instance.constructor);
+      }
+    } catch (e) {
+      // Factory not available - bailout
+      return null;
+    }
+  }
+
+  private _updateCompFactory() {
+    this._compFactory = this._resolveCompFactory();
+  }
+
+  private _resolveInputs(inputs: any): any {
+    if (!this._compFactory) {
+      return inputs;
+    }
+
+    return this._remapIO(inputs, this._compFactory.inputs);
+  }
+
+  private _resolveOutputs(outputs: any): any {
+    if (!this._compFactory) {
+      return outputs;
+    }
+
+    return this._remapIO(outputs, this._compFactory.outputs);
+  }
+
+  private _resolveChanges(changes: SimpleChanges): SimpleChanges {
+    if (!this._compFactory) {
+      return changes;
+    }
+
+    return this._remapIO(changes, this._compFactory.inputs);
+  }
+
+  private _remapIO(io: any, mapping: IOMappingList): any {
+    const newIO = {};
+
+    Object.keys(io).forEach((key) => {
+      const newKey = this._findPropByTplInMapping(key, mapping) || key;
+      newIO[newKey] = io[key];
+    });
+
+    return newIO;
+  }
+
+  private _findPropByTplInMapping(tplName: string, mapping: IOMappingList): string | null {
+    for (const map of mapping) {
+      if (map.templateName === tplName) {
+        return map.propName;
+      }
+    }
+    return null;
+  }
+
+  private failInit() {
+    throw Error('IoService: ComponentInjector was not set! Please call init() method!');
+  }
+}

--- a/src/dynamic/util.ts
+++ b/src/dynamic/util.ts
@@ -24,13 +24,13 @@ export function setChangeFromRecord(
 }
 
 function getChangesRecords(isFirstChanges: boolean) {
-  return (changes: SimpleChanges) => setChangeFromRecord(isFirstChanges,
-    (record, change) => changes[record.key] = change);
+  return (changes: SimpleChanges) =>
+    setChangeFromRecord(isFirstChanges, (record, change) => (changes[record.key] = change));
 }
 
 function getNewChangesRecords(isFirstChanges: boolean) {
-  return (changes: SimpleChanges) => setChangeFromRecord(isFirstChanges,
-    (record, change) => {
+  return (changes: SimpleChanges) =>
+    setChangeFromRecord(isFirstChanges, (record, change) => {
       if (!changes[record.key]) {
         changes[record.key] = change;
       }
@@ -44,10 +44,10 @@ export const defaultOpts = {
 
 export type DefaultOpts = Partial<typeof defaultOpts>;
 
-export function changesFromRecord(
-  opts: DefaultOpts = defaultOpts,
-) {
+export function changesFromRecord(opts: DefaultOpts = defaultOpts) {
   return opts.onlyNewChanges
     ? getNewChangesRecords(opts.isFirstChanges)
     : getChangesRecords(opts.isFirstChanges);
 }
+
+export function noop(...args: any[]): void {}

--- a/src/dynamic/util.ts
+++ b/src/dynamic/util.ts
@@ -59,7 +59,7 @@ export function changesFromRecord(opts: DefaultOpts = defaultOpts) {
     : getChangesRecords(opts.isFirstChanges);
 }
 
-export function noop(...args: any[]): void {}
+export function noop(): void {}
 
 export function getCtorType(ctor: any): any[] {
   return Reflect.getMetadata('design:paramtypes', ctor);

--- a/src/dynamic/util.ts
+++ b/src/dynamic/util.ts
@@ -1,5 +1,7 @@
 import { KeyValueChangeRecord, SimpleChange, SimpleChanges } from '@angular/core';
 
+const { Reflect } = window as any;
+
 export type KeyValueChangeRecordAny = KeyValueChangeRecord<any, any>;
 
 export function createNewChange(val: any): SimpleChange {
@@ -51,3 +53,7 @@ export function changesFromRecord(opts: DefaultOpts = defaultOpts) {
 }
 
 export function noop(...args: any[]): void {}
+
+export function getCtorType(ctor: any): any[] {
+  return Reflect.getMetadata('design:paramtypes', ctor);
+}

--- a/src/test/util.ts
+++ b/src/test/util.ts
@@ -2,6 +2,10 @@ import { DebugElement, Type } from '@angular/core';
 import { ComponentFixture } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 
+export function getDirective<T>(dirType: Type<T>) {
+  return getByPredicate<T>(By.directive(dirType));
+}
+
 export function getByPredicate<T>(predicate: any) {
   return (fixture: ComponentFixture<any>) => getCompFrom<T>(predicate, fixture);
 }


### PR DESCRIPTION
_NOTE:_ This is still in research phase.

- [x] **Steps to be completed for MVP feature:**
  - [x] Refactor inputs and outputs logic from `DynamicDirective` into service so it can be reused
  - [x] Create basic `DynamicDirectives` directive that can attach directives to dynamic component
  - [x] Fix potential injector inconsistencies
  - [x] Add support of inputs/outputs for each dynamic directive

- [ ] **~~Optional features:~~** (too complex to implement for now)
  - [ ] Add support for queries (`@ViewChild`, `@ContentChildren` etc.)
  - [ ] Add support for host related decorators (`@HostListener`, `@HostBinding` etc.)

Research is done here: https://github.com/gund/test-dynamic-directives
