### PR TITLE
[Fix] Component's change detection

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,8 @@
 {
-    "typescript.tsdk": "node_modules\\typescript\\lib"
+    "typescript.tsdk": "node_modules\\typescript\\lib",
+    "workbench.colorCustomizations": {
+        "activityBar.background": "#1F2A5A",
+        "titleBar.activeBackground": "#2B3B7E",
+        "titleBar.activeForeground": "#F9FAFD"
+    }
 }

--- a/src/dynamic/dynamic-directives.directive.ts
+++ b/src/dynamic/dynamic-directives.directive.ts
@@ -232,6 +232,7 @@ export class DynamicDirectivesDirective implements OnDestroy, DoCheck {
       ...this.componentRef,
       destroy: this.componentRef.destroy,
       onDestroy: this.componentRef.onDestroy,
+      injector: this.componentRef.injector,
       instance: dir.instance,
       componentType: dir.type,
     };

--- a/src/dynamic/dynamic.directive.spec.ts
+++ b/src/dynamic/dynamic.directive.spec.ts
@@ -1,4 +1,4 @@
-import { SimpleChanges } from '@angular/core';
+import { SimpleChanges, ChangeDetectorRef } from '@angular/core';
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { Observable, Subject } from 'rxjs';
@@ -93,6 +93,17 @@ describe('Directive: Dynamic', () => {
       fixture.detectChanges();
 
       expect(injectedComp.ngOnChanges).toHaveBeenCalledTimes(1);
+    });
+
+    it('should trigger markForCheck of component`s `ChangeDetectorRef`', () => {
+      const cdr = { markForCheck: jest.fn() };
+      injectorComp.injectorGet.mockReturnValue(cdr);
+
+      fixture.detectChanges();
+
+      expect(injectedComp.ngOnChanges).toHaveBeenCalledTimes(1);
+      expect(injectorComp.injectorGet).toHaveBeenCalledWith(ChangeDetectorRef);
+      expect(cdr.markForCheck).toHaveBeenCalled();
     });
 
     it('should trigger `OnChanges` life-cycle hook on updates', () => {

--- a/src/dynamic/io.service.ts
+++ b/src/dynamic/io.service.ts
@@ -1,9 +1,11 @@
 import {
+  ChangeDetectorRef,
   ComponentFactory,
   ComponentFactoryResolver,
   Injectable,
   KeyValueChanges,
   KeyValueDiffers,
+  OnDestroy,
   SimpleChanges,
 } from '@angular/core';
 import { Subject } from 'rxjs';
@@ -11,7 +13,6 @@ import { takeUntil } from 'rxjs/operators';
 
 import { ComponentInjector } from './component-injector';
 import { changesFromRecord, createNewChange, noop } from './util';
-import { OnDestroy } from '@angular/core';
 
 export type InputsType = { [k: string]: any };
 export type OutputsType = { [k: string]: Function };
@@ -56,6 +57,10 @@ export class IoService implements OnDestroy {
     } else {
       return false;
     }
+  }
+
+  private get _compCdr(): ChangeDetectorRef {
+    return this._compRef ? this._compRef.injector.get(ChangeDetectorRef) : null;
   }
 
   constructor(
@@ -150,6 +155,11 @@ export class IoService implements OnDestroy {
     inputs = this._resolveInputs(inputs);
 
     Object.keys(inputs).forEach(p => (compInst[p] = inputs[p]));
+
+    // Mark component for check to re-render with new inputs
+    if (this._compCdr) {
+      this._compCdr.markForCheck();
+    }
 
     this.notifyOnInputChanges(this._lastInputChanges, isFirstChange);
   }

--- a/src/test/component-injector.component.ts
+++ b/src/test/component-injector.component.ts
@@ -7,11 +7,15 @@ import { Component, ComponentRef, EventEmitter, Input } from '@angular/core';
 })
 export class ComponentInjectorComponent implements ComponentInjector {
   component = new MockedInjectedComponent();
+  injectorGet = jest.fn();
 
   get componentRef(): ComponentRef<ComponentInjectorComponent> {
-    return this.component ? {
-      instance: this.component,
-    } as any : null;
+    return this.component
+      ? ({
+          instance: this.component,
+          injector: { get: this.injectorGet },
+        } as any)
+      : null;
   }
 }
 


### PR DESCRIPTION
Previously dynamic component was not marked for check when changes were made in inputs.

This was causing inconsistent rendering if original update event was triggered outside of the dynamic component.

Now on every inputs change dynamic component will be marked for check.
