### PR TITLE
Fix issues with barrel files and ng-packagr

### DIFF
--- a/projects/ng-dynamic-component/src/lib/dynamic-attributes/dynamic-attributes.directive.spec.ts
+++ b/projects/ng-dynamic-component/src/lib/dynamic-attributes/dynamic-attributes.directive.spec.ts
@@ -10,10 +10,8 @@ import {
   TestComponent as TestComponentBase,
   TestModule,
 } from '../../test';
-import {
-  ComponentOutletInjectorDirective,
-  DynamicComponentInjectorToken,
-} from '../component-injector';
+import { ComponentOutletInjectorDirective } from '../component-injector/component-outlet-injector.directive';
+import { DynamicComponentInjectorToken } from '../component-injector/token';
 import { DynamicComponent } from '../dynamic.component';
 import {
   AttributesMap,

--- a/projects/ng-dynamic-component/src/lib/dynamic-attributes/dynamic-attributes.directive.ts
+++ b/projects/ng-dynamic-component/src/lib/dynamic-attributes/dynamic-attributes.directive.ts
@@ -13,7 +13,10 @@ import {
 } from '@angular/core';
 
 import { ComponentOutletInjectorDirective } from '../component-injector/component-outlet-injector.directive';
-import { DynamicComponentInjector, DynamicComponentInjectorToken } from '../component-injector/token';
+import {
+  DynamicComponentInjector,
+  DynamicComponentInjectorToken,
+} from '../component-injector/token';
 
 export interface AttributesMap {
   [key: string]: string;

--- a/projects/ng-dynamic-component/src/lib/dynamic-attributes/dynamic-attributes.directive.ts
+++ b/projects/ng-dynamic-component/src/lib/dynamic-attributes/dynamic-attributes.directive.ts
@@ -12,11 +12,8 @@ import {
   Type,
 } from '@angular/core';
 
-import {
-  ComponentOutletInjectorDirective,
-  DynamicComponentInjector,
-  DynamicComponentInjectorToken,
-} from '../component-injector';
+import { ComponentOutletInjectorDirective } from '../component-injector/component-outlet-injector.directive';
+import { DynamicComponentInjector, DynamicComponentInjectorToken } from '../component-injector/token';
 
 export interface AttributesMap {
   [key: string]: string;

--- a/projects/ng-dynamic-component/src/lib/dynamic-directives/dynamic-directives.directive.spec.ts
+++ b/projects/ng-dynamic-component/src/lib/dynamic-directives/dynamic-directives.directive.spec.ts
@@ -30,7 +30,10 @@ import {
 import { ComponentOutletInjectorDirective } from '../component-injector/component-outlet-injector.directive';
 import { DynamicComponentInjectorToken } from '../component-injector/token';
 import { IoFactoryService } from '../io/io-factory.service';
-import { WindowRefToken, WindowRefService } from '../window-ref/window-ref.service';
+import {
+  WindowRefToken,
+  WindowRefService,
+} from '../window-ref/window-ref.service';
 import {
   DirectiveRef,
   DynamicDirectiveDef,

--- a/projects/ng-dynamic-component/src/lib/dynamic-directives/dynamic-directives.directive.spec.ts
+++ b/projects/ng-dynamic-component/src/lib/dynamic-directives/dynamic-directives.directive.spec.ts
@@ -27,12 +27,10 @@ import {
   TestComponent,
   TestModule,
 } from '../../test';
-import {
-  ComponentOutletInjectorDirective,
-  DynamicComponentInjectorToken,
-} from '../component-injector';
-import { IoFactoryService } from '../io';
-import { WindowRefToken, WindowRefService } from '../window-ref';
+import { ComponentOutletInjectorDirective } from '../component-injector/component-outlet-injector.directive';
+import { DynamicComponentInjectorToken } from '../component-injector/token';
+import { IoFactoryService } from '../io/io-factory.service';
+import { WindowRefToken, WindowRefService } from '../window-ref/window-ref.service';
 import {
   DirectiveRef,
   DynamicDirectiveDef,

--- a/projects/ng-dynamic-component/src/lib/dynamic-directives/dynamic-directives.directive.ts
+++ b/projects/ng-dynamic-component/src/lib/dynamic-directives/dynamic-directives.directive.ts
@@ -19,14 +19,16 @@ import {
   ViewRef,
 } from '@angular/core';
 
+import { ComponentOutletInjectorDirective } from '../component-injector/component-outlet-injector.directive';
 import {
-  ComponentOutletInjectorDirective,
   DynamicComponentInjector,
   DynamicComponentInjectorToken,
-} from '../component-injector';
-import { InputsType, IoFactoryService, IoService, OutputsType } from '../io';
+} from '../component-injector/token';
+import { IoService } from '../io/io.service';
+import { IoFactoryService  } from '../io/io-factory.service';
+import { InputsType, OutputsType } from '../io/types';
 import { getCtorType } from '../util';
-import { WindowRefService } from '../window-ref';
+import { WindowRefService } from '../window-ref/window-ref.service';
 
 export interface DynamicDirectiveDef<T> {
   type: Type<T>;

--- a/projects/ng-dynamic-component/src/lib/dynamic-directives/dynamic-directives.directive.ts
+++ b/projects/ng-dynamic-component/src/lib/dynamic-directives/dynamic-directives.directive.ts
@@ -25,7 +25,7 @@ import {
   DynamicComponentInjectorToken,
 } from '../component-injector/token';
 import { IoService } from '../io/io.service';
-import { IoFactoryService  } from '../io/io-factory.service';
+import { IoFactoryService } from '../io/io-factory.service';
 import { InputsType, OutputsType } from '../io/types';
 import { getCtorType } from '../util';
 import { WindowRefService } from '../window-ref/window-ref.service';

--- a/projects/ng-dynamic-component/src/lib/dynamic-io/dynamic-io.directive.spec.ts
+++ b/projects/ng-dynamic-component/src/lib/dynamic-io/dynamic-io.directive.spec.ts
@@ -13,12 +13,10 @@ import {
   TestComponent,
   TestModule,
 } from '../../test';
-import {
-  ComponentOutletInjectorDirective,
-  DynamicComponentInjectorToken,
-} from '../component-injector';
+import { ComponentOutletInjectorDirective } from '../component-injector/component-outlet-injector.directive';
+import { DynamicComponentInjectorToken } from '../component-injector/token';
 import { DynamicIoDirective } from './dynamic-io.directive';
-import { EventArgumentToken } from '../io';
+import { EventArgumentToken } from '../io/event-argument';
 
 const getComponentInjectorFrom = getByPredicate<ComponentInjectorComponent>(
   By.directive(ComponentInjectorComponent),

--- a/projects/ng-dynamic-component/src/lib/dynamic-io/dynamic-io.directive.ts
+++ b/projects/ng-dynamic-component/src/lib/dynamic-io/dynamic-io.directive.ts
@@ -9,12 +9,10 @@ import {
   SimpleChanges,
 } from '@angular/core';
 
-import {
-  ComponentOutletInjectorDirective,
-  DynamicComponentInjector,
-  DynamicComponentInjectorToken,
-} from '../component-injector';
-import { InputsType, IoService, OutputsType } from '../io';
+import { ComponentOutletInjectorDirective } from '../component-injector/component-outlet-injector.directive';
+import { DynamicComponentInjector, DynamicComponentInjectorToken } from '../component-injector/token';
+import { IoService } from '../io/io.service';
+import { InputsType, OutputsType } from '../io/types';
 
 // tslint:disable-next-line: no-conflicting-lifecycle
 @Directive({

--- a/projects/ng-dynamic-component/src/lib/dynamic-io/dynamic-io.directive.ts
+++ b/projects/ng-dynamic-component/src/lib/dynamic-io/dynamic-io.directive.ts
@@ -10,7 +10,10 @@ import {
 } from '@angular/core';
 
 import { ComponentOutletInjectorDirective } from '../component-injector/component-outlet-injector.directive';
-import { DynamicComponentInjector, DynamicComponentInjectorToken } from '../component-injector/token';
+import {
+  DynamicComponentInjector,
+  DynamicComponentInjectorToken,
+} from '../component-injector/token';
 import { IoService } from '../io/io.service';
 import { InputsType, OutputsType } from '../io/types';
 

--- a/projects/ng-dynamic-component/src/lib/dynamic-io/dynamic-io.module.ts
+++ b/projects/ng-dynamic-component/src/lib/dynamic-io/dynamic-io.module.ts
@@ -1,7 +1,7 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 
-import { ComponentOutletInjectorModule } from '../component-injector';
+import { ComponentOutletInjectorModule } from '../component-injector/component-outlet-injector.module';
 import { DynamicIoDirective } from './dynamic-io.directive';
 
 @NgModule({

--- a/projects/ng-dynamic-component/src/lib/dynamic.component.module.ts
+++ b/projects/ng-dynamic-component/src/lib/dynamic.component.module.ts
@@ -1,12 +1,12 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 
-import { DynamicIoModule } from './dynamic-io';
+import { DynamicIoModule } from './dynamic-io/dynamic-io.module';
 import { DynamicComponent } from './dynamic.component';
 
 @NgModule({
   imports: [CommonModule, DynamicIoModule],
   exports: [DynamicComponent, DynamicIoModule],
-  declarations: [DynamicComponent],
+  declarations: [DynamicComponent]
 })
-export class DynamicComponentModule {}
+export class DynamicComponentModule { }

--- a/projects/ng-dynamic-component/src/lib/dynamic.component.module.ts
+++ b/projects/ng-dynamic-component/src/lib/dynamic.component.module.ts
@@ -7,6 +7,6 @@ import { DynamicComponent } from './dynamic.component';
 @NgModule({
   imports: [CommonModule, DynamicIoModule],
   exports: [DynamicComponent, DynamicIoModule],
-  declarations: [DynamicComponent]
+  declarations: [DynamicComponent],
 })
-export class DynamicComponentModule { }
+export class DynamicComponentModule {}

--- a/projects/ng-dynamic-component/src/lib/dynamic.module.ts
+++ b/projects/ng-dynamic-component/src/lib/dynamic.module.ts
@@ -1,13 +1,10 @@
 import { ModuleWithProviders, NgModule, Type } from '@angular/core';
 
-import {
-  ComponentOutletInjectorModule,
-  DynamicComponentInjector,
-  DynamicComponentInjectorToken,
-} from './component-injector';
-import { DynamicAttributesModule } from './dynamic-attributes';
-import { DynamicDirectivesModule } from './dynamic-directives';
-import { DynamicIoModule } from './dynamic-io';
+import { ComponentOutletInjectorModule } from './component-injector/component-outlet-injector.module';
+import { DynamicComponentInjector, DynamicComponentInjectorToken } from './component-injector/token';
+import { DynamicAttributesModule } from './dynamic-attributes/dynamic-attributes.module';
+import { DynamicDirectivesModule } from './dynamic-directives/dynamic-directives.module';
+import { DynamicIoModule } from './dynamic-io/dynamic-io.module';
 import { DynamicComponent } from './dynamic.component';
 import { DynamicComponentModule } from './dynamic.component.module';
 

--- a/projects/ng-dynamic-component/src/lib/dynamic.module.ts
+++ b/projects/ng-dynamic-component/src/lib/dynamic.module.ts
@@ -1,7 +1,10 @@
 import { ModuleWithProviders, NgModule, Type } from '@angular/core';
 
 import { ComponentOutletInjectorModule } from './component-injector/component-outlet-injector.module';
-import { DynamicComponentInjector, DynamicComponentInjectorToken } from './component-injector/token';
+import {
+  DynamicComponentInjector,
+  DynamicComponentInjectorToken,
+} from './component-injector/token';
 import { DynamicAttributesModule } from './dynamic-attributes/dynamic-attributes.module';
 import { DynamicDirectivesModule } from './dynamic-directives/dynamic-directives.module';
 import { DynamicIoModule } from './dynamic-io/dynamic-io.module';

--- a/projects/ng-dynamic-component/src/lib/io/io.service.ts
+++ b/projects/ng-dynamic-component/src/lib/io/io.service.ts
@@ -12,7 +12,7 @@ import {
 import { Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
 
-import { DynamicComponentInjector } from '../component-injector';
+import { DynamicComponentInjector } from '../component-injector/token';
 import { changesFromRecord, createNewChange, noop } from '../util';
 import { EventArgumentToken } from './event-argument';
 import { EventHandler, InputsType, OutputsType, OutputWithArgs } from './types';


### PR DESCRIPTION
I was trying to use your fantastic library in my own library but wasn't able to build. 

After some investigation it turns out that ng-packagr isn't playing nice with barrel files (the index.ts files in your project). See also https://github.com/ng-packagr/ng-packagr/issues/1173

The error is got during compilation was: 
```bash
ERROR: Unexpected value 'undefined' imported by the module 'DynamicComponentModule in ./node_modules/ng-dynamic-component/ng-dynamic-component.d.ts'
Unexpected value 'undefined' exported by the module 'DynamicComponentModule in ./node_modules/ng-dynamic-component/ng-dynamic-component.d.ts'
Unexpected value 'undefined' exported by the module 'DynamicModule in ./node_modules/ng-dynamic-component/ng-dynamic-component.d.ts'

An unhandled exception occurred: Unexpected value 'undefined' imported by the module 'DynamicComponentModule in ./node_modules/ng-dynamic-component/ng-dynamic-component.d.ts'
Unexpected value 'undefined' exported by the module 'DynamicComponentModule in ./node_modules/ng-dynamic-component/ng-dynamic-component.d.ts'
Unexpected value 'undefined' exported by the module 'DynamicModule in ./node_modules/ng-dynamic-component/ng-dynamic-component.d.ts'
```


# Reproduction
With Angular CLI: 9.1.0

```bash
ng new test-project --create-application=false
cd test-project
npm install ng-dynamic-component@6.1.0
ng g library testlib
```

now edit `projects/testlib/src/lib/testlib.module.ts` so that it looks like:
```typescript
import { NgModule } from '@angular/core';
import { TestlibComponent } from './testlib.component';

import { DynamicComponentModule } from 'ng-dynamic-component';


@NgModule({
  declarations: [TestlibComponent],
  imports: [
    DynamicComponentModule
  ],
  exports: [TestlibComponent]
})
export class TestlibModule { }
```

Finally run `ng build --prod`