### PR TITLE
[Fix] Constructor arguments resolution in dynamic directives

### DIFF
--- a/projects/ng-dynamic-component/src/lib/component-injector/component-outlet-injector.directive.ts
+++ b/projects/ng-dynamic-component/src/lib/component-injector/component-outlet-injector.directive.ts
@@ -20,6 +20,7 @@ import {
 export class ComponentOutletInjectorDirective
   implements DynamicComponentInjector {
   get componentRef(): ComponentRef<any> {
+    // NOTE: Accessing private APIs of Angular
     return (this.componentOutlet as any)._componentRef;
   }
 

--- a/projects/ng-dynamic-component/src/lib/dynamic-attributes/dynamic-attributes.directive.ts
+++ b/projects/ng-dynamic-component/src/lib/dynamic-attributes/dynamic-attributes.directive.ts
@@ -1,7 +1,6 @@
 import {
   Directive,
   DoCheck,
-  Host,
   Inject,
   Injector,
   Input,
@@ -13,7 +12,6 @@ import {
 } from '@angular/core';
 
 import {
-  ComponentOutletInjectorDirective,
   DynamicComponentInjector,
   DynamicComponentInjectorToken,
 } from '../component-injector';
@@ -47,22 +45,12 @@ export class DynamicAttributesDirective implements DoCheck {
     );
   }
 
-  private get _compInjector() {
-    return this.componentOutletInjector || this.componentInjector;
-  }
-
   private get _nativeElement() {
-    return (
-      this._compInjector.componentRef &&
-      this._compInjector.componentRef.location.nativeElement
-    );
+    return this.componentInjector.componentRef?.location.nativeElement;
   }
 
   private get _compType() {
-    return (
-      this._compInjector.componentRef &&
-      this._compInjector.componentRef.componentType
-    );
+    return this.componentInjector.componentRef?.componentType;
   }
 
   private get _isCompChanged() {
@@ -80,9 +68,6 @@ export class DynamicAttributesDirective implements DoCheck {
     @Inject(DynamicComponentInjectorToken)
     @Optional()
     private componentInjector?: DynamicComponentInjector,
-    @Host()
-    @Optional()
-    private componentOutletInjector?: ComponentOutletInjectorDirective,
   ) {}
 
   ngDoCheck(): void {

--- a/projects/ng-dynamic-component/src/lib/dynamic-attributes/dynamic-attributes.module.ts
+++ b/projects/ng-dynamic-component/src/lib/dynamic-attributes/dynamic-attributes.module.ts
@@ -1,11 +1,12 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 
+import { ComponentOutletInjectorModule } from '../component-injector';
 import { DynamicAttributesDirective } from './dynamic-attributes.directive';
 
 @NgModule({
   imports: [CommonModule],
-  exports: [DynamicAttributesDirective],
+  exports: [DynamicAttributesDirective, ComponentOutletInjectorModule],
   declarations: [DynamicAttributesDirective],
 })
 export class DynamicAttributesModule {}

--- a/projects/ng-dynamic-component/src/lib/dynamic-directives/dynamic-directives.module.ts
+++ b/projects/ng-dynamic-component/src/lib/dynamic-directives/dynamic-directives.module.ts
@@ -1,11 +1,12 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 
+import { ComponentOutletInjectorModule } from '../component-injector';
 import { DynamicDirectivesDirective } from './dynamic-directives.directive';
 
 @NgModule({
   imports: [CommonModule],
-  exports: [DynamicDirectivesDirective],
+  exports: [DynamicDirectivesDirective, ComponentOutletInjectorModule],
   declarations: [DynamicDirectivesDirective],
 })
 export class DynamicDirectivesModule {}

--- a/projects/ng-dynamic-component/src/lib/dynamic-io/dynamic-io.directive.ts
+++ b/projects/ng-dynamic-component/src/lib/dynamic-io/dynamic-io.directive.ts
@@ -1,7 +1,6 @@
 import {
   Directive,
   DoCheck,
-  Host,
   Inject,
   Input,
   OnChanges,
@@ -10,7 +9,6 @@ import {
 } from '@angular/core';
 
 import {
-  ComponentOutletInjectorDirective,
   DynamicComponentInjector,
   DynamicComponentInjectorToken,
 } from '../component-injector';
@@ -40,20 +38,13 @@ export class DynamicIoDirective implements OnChanges, DoCheck {
     return this.ndcDynamicOutputs || this.ngComponentOutletNdcDynamicOutputs;
   }
 
-  private get compInjector() {
-    return this.componentOutletInjector || this.componentInjector;
-  }
-
   constructor(
     private ioService: IoService,
     @Inject(DynamicComponentInjectorToken)
     @Optional()
     private componentInjector?: DynamicComponentInjector,
-    @Host()
-    @Optional()
-    private componentOutletInjector?: ComponentOutletInjectorDirective,
   ) {
-    this.ioService.init(this.compInjector);
+    this.ioService.init(this.componentInjector);
   }
 
   ngOnChanges(changes: SimpleChanges) {

--- a/projects/ng-dynamic-component/src/lib/dynamic-io/dynamic-io.module.ts
+++ b/projects/ng-dynamic-component/src/lib/dynamic-io/dynamic-io.module.ts
@@ -5,7 +5,7 @@ import { ComponentOutletInjectorModule } from '../component-injector';
 import { DynamicIoDirective } from './dynamic-io.directive';
 
 @NgModule({
-  imports: [CommonModule, ComponentOutletInjectorModule],
+  imports: [CommonModule],
   exports: [DynamicIoDirective, ComponentOutletInjectorModule],
   declarations: [DynamicIoDirective],
 })

--- a/projects/ng-dynamic-component/src/lib/util.spec.ts
+++ b/projects/ng-dynamic-component/src/lib/util.spec.ts
@@ -1,0 +1,31 @@
+import { NgClass } from '@angular/common';
+
+import { extractNgParamTypes } from './util';
+import { Component } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+
+describe('Util', () => {
+  describe('function extractNgParamTypes()', () => {
+    it('should return constructor argument types collected by NGC', () => {
+      const args = extractNgParamTypes(NgClass);
+
+      // To be more flexible just check that there are some arguments
+      // and do not check for specific types as they are irrelevant and may change
+      expect(args.length).toBeGreaterThan(0);
+    });
+
+    it('should return `undefined` for constructor not processed by NGC', () => {
+      // tslint:disable-next-line: component-selector
+      @Component({ selector: 'test', template: '' })
+      class TestComponent {}
+
+      TestBed.configureTestingModule({
+        declarations: [TestComponent],
+      }).compileComponents();
+
+      const args = extractNgParamTypes(TestComponent);
+
+      expect(args).toBe(undefined);
+    });
+  });
+});

--- a/projects/ng-dynamic-component/src/lib/util.ts
+++ b/projects/ng-dynamic-component/src/lib/util.ts
@@ -2,6 +2,7 @@ import {
   KeyValueChangeRecord,
   SimpleChange,
   SimpleChanges,
+  Type,
 } from '@angular/core';
 
 export type KeyValueChangeRecordAny = KeyValueChangeRecord<any, any>;
@@ -59,9 +60,17 @@ export function changesFromRecord(opts: DefaultOpts = defaultOpts) {
 
 export function noop(): void {}
 
-export function getCtorType(
+export function getCtorParamTypes(
   ctor: any,
   reflect: { getMetadata: (type: string, obj: object) => any[] },
 ): any[] {
   return reflect.getMetadata('design:paramtypes', ctor);
+}
+
+/**
+ * Extract type arguments from Angular Directive/Component
+ */
+export function extractNgParamTypes(type: Type<any>): any[] | undefined {
+  // NOTE: Accessing private APIs of Angular
+  return (type as any)?.ctorParameters?.()?.map(param => param.type);
 }

--- a/projects/ng-dynamic-component/src/test/component-injector.component.ts
+++ b/projects/ng-dynamic-component/src/test/component-injector.component.ts
@@ -23,6 +23,7 @@ export class ComponentInjectorComponent implements DynamicComponentInjector {
   get componentRef(): ComponentRef<ComponentInjectorComponent> {
     return this.component
       ? ({
+          componentType: MockedInjectedComponent,
           instance: this.component,
           injector: { get: this.injectorGet },
         } as any)


### PR DESCRIPTION
Since Angular v10 directives no longer contain their constructor arguments in Reflect API and instead NGC stores it in private API.
Now library tries to access that private API first to resolve arguments and if it fails falls back to Reflect API.