### PR TITLE
fix(429): markForCheck when calling event handler

### DIFF
--- a/projects/ng-dynamic-component/src/lib/dynamic-directives/dynamic-directives.directive.ts
+++ b/projects/ng-dynamic-component/src/lib/dynamic-directives/dynamic-directives.directive.ts
@@ -54,6 +54,7 @@ export interface DirectiveRef<T> {
 
 @Directive({
   selector: '[ndcDynamicDirectives],[ngComponentOutletNdcDynamicDirectives]',
+  providers: [IoFactoryService],
 })
 export class DynamicDirectivesDirective implements OnDestroy, DoCheck {
   @Input()

--- a/projects/ng-dynamic-component/src/lib/io/io-factory.service.spec.ts
+++ b/projects/ng-dynamic-component/src/lib/io/io-factory.service.spec.ts
@@ -1,3 +1,4 @@
+import { ChangeDetectorRef } from '@angular/core';
 import { inject, TestBed } from '@angular/core/testing';
 
 import { IoFactoryService } from './io-factory.service';
@@ -5,7 +6,10 @@ import { IoFactoryService } from './io-factory.service';
 describe('Service: IoFactory', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
-      providers: [IoFactoryService],
+      providers: [
+        IoFactoryService,
+        { provide: ChangeDetectorRef, useValue: {} },
+      ],
     });
   });
 

--- a/projects/ng-dynamic-component/src/lib/io/io-factory.service.ts
+++ b/projects/ng-dynamic-component/src/lib/io/io-factory.service.ts
@@ -1,4 +1,5 @@
 import {
+  ChangeDetectorRef,
   ComponentFactoryResolver,
   Inject,
   Injectable,
@@ -8,16 +9,17 @@ import {
 import { EventArgumentToken } from './event-argument';
 import { IoService } from './io.service';
 
-@Injectable({ providedIn: 'root' })
+@Injectable()
 export class IoFactoryService {
   constructor(
     private differs: KeyValueDiffers,
     private cfr: ComponentFactoryResolver,
     @Inject(EventArgumentToken)
     private eventArgument: string,
+    private cdr: ChangeDetectorRef,
   ) {}
 
   create() {
-    return new IoService(this.differs, this.cfr, this.eventArgument);
+    return new IoService(this.differs, this.cfr, this.eventArgument, this.cdr);
   }
 }

--- a/projects/ng-dynamic-component/src/lib/io/io.service.spec.ts
+++ b/projects/ng-dynamic-component/src/lib/io/io.service.spec.ts
@@ -1,3 +1,4 @@
+import { ChangeDetectorRef } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 
 import { IoService } from './io.service';
@@ -7,7 +8,7 @@ describe('Service: Io', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      providers: [IoService],
+      providers: [IoService, { provide: ChangeDetectorRef, useValue: {} }],
     });
     service = TestBed.inject(IoService);
   });

--- a/projects/ng-dynamic-component/src/lib/io/io.service.ts
+++ b/projects/ng-dynamic-component/src/lib/io/io.service.ts
@@ -74,6 +74,7 @@ export class IoService implements OnDestroy {
     private cfr: ComponentFactoryResolver,
     @Inject(EventArgumentToken)
     private eventArgument: string,
+    private cdr: ChangeDetectorRef,
   ) {}
 
   ngOnDestroy(): void {
@@ -166,7 +167,6 @@ export class IoService implements OnDestroy {
     inputs = this._resolveInputs(inputs);
 
     Object.keys(inputs).forEach(p => (compInst[p] = inputs[p]));
-
     // Mark component for check to re-render with new inputs
     if (this.compCdr) {
       this.compCdr.markForCheck();
@@ -192,7 +192,10 @@ export class IoService implements OnDestroy {
       .forEach(p =>
         compInst[p]
           .pipe(takeUntil(this.outputsShouldDisconnect$))
-          .subscribe((event: any) => (outputs[p] as EventHandler)(event)),
+          .subscribe((event: any) => {
+            this.cdr.markForCheck();
+            return (outputs[p] as EventHandler)(event);
+          }),
       );
   }
 


### PR DESCRIPTION
IoService calls `markForCheck` on the on the host component's change detector before an event handler is called.
It's done *before* calling the event handler on purpose: this way the flag is reset the handler calls `detectChanges` and there's no additional change detection after the current tick. This also seems to be what Angular does in templates.

Note that I had difficulties understanding the tests. Therefore I duplicated a bit of code to make my tests work without affecting everything else.

Fixes: #429 