### PR TITLE
fix(api): add missing ngOnDestroy method back to IoService

### DIFF
--- a/goldens/ng-dynamic-component/api.md
+++ b/goldens/ng-dynamic-component/api.md
@@ -309,7 +309,7 @@ export interface IoFactoryServiceOptions {
 // @public (undocumented)
 export class IoService implements OnDestroy {
     constructor(injector: Injector, differs: KeyValueDiffers, cfr: ComponentFactoryResolver, options: IoServiceOptions, compInjector: DynamicComponentInjector, eventArgument: string, cdr: ChangeDetectorRef, eventContextProvider: StaticProvider, componentIO: ComponentIO);
-    // @internal (undocumented)
+    // (undocumented)
     ngOnDestroy(): void;
     update(inputs?: InputsType | null, outputs?: OutputsType | null): void;
     // (undocumented)

--- a/projects/ng-dynamic-component/src/lib/io/io.service.ts
+++ b/projects/ng-dynamic-component/src/lib/io/io.service.ts
@@ -102,7 +102,6 @@ export class IoService implements OnDestroy {
     }
   }
 
-  /** @internal */
   ngOnDestroy(): void {
     this.disconnectOutputs();
   }


### PR DESCRIPTION
Add missing ngOnDestroy method back to IoService by removing `@internal` jsdoc from it.

Closes #522
