### PR TITLE
chore(ci): Migrate to NPM trusted publisher OIDC flow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,13 +12,20 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
+permissions:
+  id-token: write  # Required for OIDC trusted publishing
+  contents: read
+
 jobs:
   release:
     runs-on: ubuntu-latest
     environment: release
     steps:
-      - uses: actions/setup-node@v3
       - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '24'
+          registry-url: 'https://registry.npmjs.org'
       - name: Install Deps
         run: npm ci --ignore-scripts
       - name: Build
@@ -26,5 +33,4 @@ jobs:
       - name: Release to NPM
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: npm run semantic-release


### PR DESCRIPTION
## Summary

Migrate the release workflow from NPM token-based authentication to [NPM trusted publishers](https://docs.npmjs.com/trusted-publishers) using OpenID Connect (OIDC). NPM-side configuration is already enabled.

### Changes

- **Add** `permissions` block with `id-token: write` (required for OIDC) and `contents: read`
- **Remove** `NPM_TOKEN` secret — OIDC provides short-lived, workflow-specific credentials
- **Update** `actions/setup-node` with `registry-url: 'https://registry.npmjs.org'` and Node 24 (required for npm CLI 11+ OIDC support)
- **Retain** `GITHUB_TOKEN` for `@semantic-release/github` (GitHub releases)

### Why

Eliminates long-lived NPM tokens, reducing the attack surface. Each publish uses a cryptographically-signed, short-lived token specific to this workflow that cannot be extracted or reused.

### Notes

- Provenance attestations will be automatically generated for publishes (no `--provenance` flag needed)
- Only 1 file changed (.github/workflows/release.yml)