### PR TITLE
ci: grant contents:write and issues:write permissions for semantic-release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,8 @@ on:
 
 permissions:
   id-token: write  # Required for OIDC trusted publishing
-  contents: read
+  contents: write   # Required for semantic-release to push tags and commits
+  issues: write    # Required for semantic-release to create issues on failure
 
 jobs:
   release:


### PR DESCRIPTION
## Problem

The release workflow (Run #31) failed with `EGITNOPERMISSION` — semantic-release could not push version tags or create GitHub issues.

### Root Cause
Commit `e50a6fbf` migrated to NPM trusted publisher OIDC flow and set:
```yaml
permissions:
  contents: read
```

This gave the GitHub Actions bot read-only access, blocking:
1. `@semantic-release/git` — needs to push version tags and changelog commits
2. `@semantic-release/github` — needs to create releases and failure notification issues

### CI Errors
- `git push --dry-run`: `remote: Permission denied to github-actions[bot]` (403)
- `POST /repos/.../issues`: `Resource not accessible by integration` (403)

## Fix

Updated the permissions block to grant write access:
```yaml
permissions:
  id-token: write   # OIDC for NPM publishing (unchanged)
  contents: write   # NEW — semantic-release pushes tags/commits
  issues: write    # NEW — semantic-release creates failure issues
```

## Impact
- Minimal 2-line change to `.github/workflows/release.yml`
- No changes to semantic-release config, build, or other workflows
- OIDC NPM publishing flow preserved