### PR TITLE
ci: remove registry-url from setup-node for OIDC trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,6 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: '24'
-          registry-url: 'https://registry.npmjs.org'
       - name: Install Deps
         run: npm ci --ignore-scripts
       - name: Build


### PR DESCRIPTION
## Problem

The automated release workflow (Issue #535) is failing with **"Invalid npm token"** error after migrating to NPM trusted publisher OIDC flow.

## Root Cause

The `registry-url: 'https://registry.npmjs.org'` option in `actions/setup-node` creates an `.npmrc` file with `_authToken=${NPM_CONFIG_NODE_AUTH_TOKEN}`. This conflicts with semantic-release's OIDC authentication because OIDC doesn't use this env var — it uses the GitHub OIDC token directly via the `id-token: write` permission.

From the [semantic-release GitHub Actions docs](https://semantic-release.gitbook.io/semantic-release/recipes/ci-configurations/github-actions):

> **Important: Avoid `registry-url` in `setup-node`** — This option can create an `.npmrc` file that conflicts with semantic-release's authentication, potentially causing `EINVALIDNPMTOKEN` errors.

## Fix

Removed `registry-url` from `actions/setup-node`. This is sufficient because:

1. `id-token: write` permission already grants OIDC access
2. npm CLI 11+ (Node 24) auto-detects GitHub Actions and uses OIDC
3. The default registry is already `registry.npmjs.org`

## Related

Fixes #535