### PR TITLE
chore(deps): upgrade @semantic-release/npm to v10 for OIDC trusted publishing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,7 @@
         "@semantic-release/exec": "^6.0.3",
         "@semantic-release/git": "^10.0.1",
         "@semantic-release/github": "^8.0.4",
-        "@semantic-release/npm": "^9.0.1",
+        "@semantic-release/npm": "^10.0.0",
         "@semantic-release/release-notes-generator": "^10.0.3",
         "@types/jest": "^28.1.1",
         "@types/node": "^16.11.11",
@@ -1467,12 +1467,14 @@
       "dev": true
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.18.6",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.18.6.tgz",
-      "integrity": "sha512-TDCmlK5eOvH+eH7cdAFlNXeVJqWIQ7gW9tY1GJIpUtFb6CmjVyq2VM3u71bOyR8CRihcCgMUYoDNyLXao3+70Q==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
       "dev": true,
       "dependencies": {
-        "@babel/highlight": "^7.18.6"
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1859,9 +1861,9 @@
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.18.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.18.6.tgz",
-      "integrity": "sha512-MmetCkz9ej86nJQV+sFCxoGGrUbU3q02kgLciwkrt9QqEB7cP39oKEY0PakknEO0Gu20SskMRi+AYZ3b1TpN9g==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
       "dev": true,
       "engines": {
         "node": ">=6.9.0"
@@ -1900,20 +1902,6 @@
         "@babel/template": "^7.18.6",
         "@babel/traverse": "^7.18.9",
         "@babel/types": "^7.18.9"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/highlight": {
-      "version": "7.18.6",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.18.6.tgz",
-      "integrity": "sha512-u7stbOuYjaPezCuLj29hNW1v64M2Md2qupEKP1fHc7WdOA3DgLh37suiSrZYY7haUB7iBeQZ9P1uiRF359do3g==",
-      "dev": true,
-      "dependencies": {
-        "@babel/helper-validator-identifier": "^7.18.6",
-        "chalk": "^2.0.0",
-        "js-tokens": "^4.0.0"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -7487,6 +7475,41 @@
         "typescript": "^3 || ^4"
       }
     },
+    "node_modules/@pnpm/config.env-replace": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@pnpm/config.env-replace/-/config.env-replace-1.1.0.tgz",
+      "integrity": "sha512-htyl8TWnKL7K/ESFa1oW2UB5lVDxuF5DpM7tBi6Hu2LNL3mWkIzNLG6N4zoCUP1lCKNxWy/3iu8mS8MvToGd6w==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.22.0"
+      }
+    },
+    "node_modules/@pnpm/network.ca-file": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@pnpm/network.ca-file/-/network.ca-file-1.0.2.tgz",
+      "integrity": "sha512-YcPQ8a0jwYU9bTdJDpXjMi7Brhkr1mXsXrUJvjqM2mQDgkRiz8jFaQGOdaLxgjtUfQgZhKy/O3cG/YwmgKaxLA==",
+      "dev": true,
+      "dependencies": {
+        "graceful-fs": "4.2.10"
+      },
+      "engines": {
+        "node": ">=12.22.0"
+      }
+    },
+    "node_modules/@pnpm/npm-conf": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@pnpm/npm-conf/-/npm-conf-3.0.3.tgz",
+      "integrity": "sha512-//0sR/cow/s4ICQaYoAobOl4aU8cjU6x/V24V7XkKotb9+O+3zySIYp146vpaobYHnxa4pZX8NkV54Z5AwbDKA==",
+      "dev": true,
+      "dependencies": {
+        "@pnpm/config.env-replace": "^1.1.0",
+        "@pnpm/network.ca-file": "^1.0.1",
+        "config-chain": "^1.1.11"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/@rollup/plugin-json": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/@rollup/plugin-json/-/plugin-json-4.1.0.tgz",
@@ -7794,30 +7817,365 @@
       "dev": true
     },
     "node_modules/@semantic-release/npm": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/@semantic-release/npm/-/npm-9.0.1.tgz",
-      "integrity": "sha512-I5nVZklxBzfMFwemhRNbSrkiN/dsH3c7K9+KSk6jUnq0rdLFUuJt7EBsysq4Ir3moajQgFkfEryEHPqiKJj20g==",
+      "version": "10.0.6",
+      "resolved": "https://registry.npmjs.org/@semantic-release/npm/-/npm-10.0.6.tgz",
+      "integrity": "sha512-DyqHrGE8aUyapA277BB+4kV0C4iMHh3sHzUWdf0jTgp5NNJxVUz76W1f57FB64Ue03him3CBXxFqQD2xGabxow==",
       "dev": true,
       "dependencies": {
-        "@semantic-release/error": "^3.0.0",
-        "aggregate-error": "^3.0.0",
-        "execa": "^5.0.0",
-        "fs-extra": "^10.0.0",
-        "lodash": "^4.17.15",
+        "@semantic-release/error": "^4.0.0",
+        "aggregate-error": "^5.0.0",
+        "execa": "^8.0.0",
+        "fs-extra": "^11.0.0",
+        "lodash-es": "^4.17.21",
         "nerf-dart": "^1.0.0",
-        "normalize-url": "^6.0.0",
-        "npm": "^8.3.0",
+        "normalize-url": "^8.0.0",
+        "npm": "^9.5.0",
         "rc": "^1.2.8",
-        "read-pkg": "^5.0.0",
-        "registry-auth-token": "^4.0.0",
+        "read-pkg": "^8.0.0",
+        "registry-auth-token": "^5.0.0",
         "semver": "^7.1.2",
-        "tempy": "^1.0.0"
+        "tempy": "^3.0.0"
       },
       "engines": {
-        "node": ">=16 || ^14.17"
+        "node": ">=18"
       },
       "peerDependencies": {
-        "semantic-release": ">=19.0.0"
+        "semantic-release": ">=20.1.0"
+      }
+    },
+    "node_modules/@semantic-release/npm/node_modules/@semantic-release/error": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@semantic-release/error/-/error-4.0.0.tgz",
+      "integrity": "sha512-mgdxrHTLOjOddRVYIYDo0fR3/v61GNN1YGkfbrjuIKg/uMgCd+Qzo3UAXJ+woLQQpos4pl5Esuw5A7AoNlzjUQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@semantic-release/npm/node_modules/aggregate-error": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-5.0.0.tgz",
+      "integrity": "sha512-gOsf2YwSlleG6IjRYG2A7k0HmBMEo6qVNk9Bp/EaLgAJT5ngH6PXbqa4ItvnEwCm/velL5jAnQgsHsWnjhGmvw==",
+      "dev": true,
+      "dependencies": {
+        "clean-stack": "^5.2.0",
+        "indent-string": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@semantic-release/npm/node_modules/clean-stack": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-5.3.0.tgz",
+      "integrity": "sha512-9ngPTOhYGQqNVSfeJkYXHmF7AGWp4/nN5D/QqNQs3Dvxd1Kk/WpjHfNujKHYUQ/5CoGyOyFNoWSPk5afzP0QVg==",
+      "dev": true,
+      "dependencies": {
+        "escape-string-regexp": "5.0.0"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@semantic-release/npm/node_modules/escape-string-regexp": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+      "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@semantic-release/npm/node_modules/execa": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-8.0.1.tgz",
+      "integrity": "sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==",
+      "dev": true,
+      "dependencies": {
+        "cross-spawn": "^7.0.3",
+        "get-stream": "^8.0.1",
+        "human-signals": "^5.0.0",
+        "is-stream": "^3.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^5.1.0",
+        "onetime": "^6.0.0",
+        "signal-exit": "^4.1.0",
+        "strip-final-newline": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=16.17"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/@semantic-release/npm/node_modules/fs-extra": {
+      "version": "11.3.6",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.6.tgz",
+      "integrity": "sha512-w8ZNZr2mKIc7qeNaQ9AVPT1+iFaI+Avd4xudVOvdDJ8VytREi1Ft5Ih7hd9jjehod8vAM5GMsfQ/TpPf4EyoEA==",
+      "dev": true,
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
+    "node_modules/@semantic-release/npm/node_modules/get-stream": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-8.0.1.tgz",
+      "integrity": "sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==",
+      "dev": true,
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@semantic-release/npm/node_modules/hosted-git-info": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-7.0.2.tgz",
+      "integrity": "sha512-puUZAUKT5m8Zzvs72XWy3HtvVbTWljRE66cP60bxJzAqf2DgICo7lYTY2IHUmLnNpjYvw5bvmoHvPc0QO2a62w==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^10.0.1"
+      },
+      "engines": {
+        "node": "^16.14.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@semantic-release/npm/node_modules/human-signals": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-5.0.0.tgz",
+      "integrity": "sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=16.17.0"
+      }
+    },
+    "node_modules/@semantic-release/npm/node_modules/indent-string": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-5.0.0.tgz",
+      "integrity": "sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@semantic-release/npm/node_modules/is-stream": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
+      "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
+      "dev": true,
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@semantic-release/npm/node_modules/json-parse-even-better-errors": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-3.0.2.tgz",
+      "integrity": "sha512-fi0NG4bPjCHunUJffmLd0gxssIgkNmArMvis4iNah6Owg1MCJjWhEcDLmsK6iGkJq3tHwbDkTlce70/tmXN4cQ==",
+      "dev": true,
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@semantic-release/npm/node_modules/lines-and-columns": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-2.0.4.tgz",
+      "integrity": "sha512-wM1+Z03eypVAVUCE7QdSqpVIvelbOakn1M0bPDoA4SGWPx3sNDVUiMo3L6To6WWGClB7VyXnhQ4Sn7gxiJbE6A==",
+      "dev": true,
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      }
+    },
+    "node_modules/@semantic-release/npm/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true
+    },
+    "node_modules/@semantic-release/npm/node_modules/mimic-fn": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
+      "integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@semantic-release/npm/node_modules/normalize-package-data": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-6.0.2.tgz",
+      "integrity": "sha512-V6gygoYb/5EmNI+MEGrWkC+e6+Rr7mTmfHrxDbLzxQogBkgzo76rkok0Am6thgSF7Mv2nLOajAJj5vDJZEFn7g==",
+      "dev": true,
+      "dependencies": {
+        "hosted-git-info": "^7.0.0",
+        "semver": "^7.3.5",
+        "validate-npm-package-license": "^3.0.4"
+      },
+      "engines": {
+        "node": "^16.14.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@semantic-release/npm/node_modules/normalize-url": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-8.1.1.tgz",
+      "integrity": "sha512-JYc0DPlpGWB40kH5g07gGTrYuMqV653k3uBKY6uITPWds3M0ov3GaWGp9lbE3Bzngx8+XkfzgvASb9vk9JDFXQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@semantic-release/npm/node_modules/npm-run-path": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.3.0.tgz",
+      "integrity": "sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==",
+      "dev": true,
+      "dependencies": {
+        "path-key": "^4.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@semantic-release/npm/node_modules/onetime": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
+      "integrity": "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==",
+      "dev": true,
+      "dependencies": {
+        "mimic-fn": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@semantic-release/npm/node_modules/parse-json": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-7.1.1.tgz",
+      "integrity": "sha512-SgOTCX/EZXtZxBE5eJ97P4yGM5n37BwRU+YMsH4vNzFqJV/oWFXXCmwFlgWUM4PrakybVOueJJ6pwHqSVhTFDw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.21.4",
+        "error-ex": "^1.3.2",
+        "json-parse-even-better-errors": "^3.0.0",
+        "lines-and-columns": "^2.0.3",
+        "type-fest": "^3.8.0"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@semantic-release/npm/node_modules/parse-json/node_modules/type-fest": {
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-3.13.1.tgz",
+      "integrity": "sha512-tLq3bSNx+xSpwvAJnzrK0Ep5CLNWjvFTOp71URMaAEWBfRb9nnJiBoUe0tF8bI4ZFO3omgBR6NvnbzVUT3Ly4g==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@semantic-release/npm/node_modules/path-key": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+      "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@semantic-release/npm/node_modules/read-pkg": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-8.1.0.tgz",
+      "integrity": "sha512-PORM8AgzXeskHO/WEv312k9U03B8K9JSiWF/8N9sUuFjBa+9SF2u6K7VClzXwDXab51jCd8Nd36CNM+zR97ScQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/normalize-package-data": "^2.4.1",
+        "normalize-package-data": "^6.0.0",
+        "parse-json": "^7.0.0",
+        "type-fest": "^4.2.0"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@semantic-release/npm/node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@semantic-release/npm/node_modules/strip-final-newline": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
+      "integrity": "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@semantic-release/npm/node_modules/type-fest": {
+      "version": "4.41.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+      "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
+      "dev": true,
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@semantic-release/release-notes-generator": {
@@ -10522,6 +10880,22 @@
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true
     },
+    "node_modules/config-chain": {
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.13.tgz",
+      "integrity": "sha512-qj+f8APARXHrM0hraqXYb2/bOVSV4PvJQlNZ/DVj0QrmNM2q2euizkeuVckQ57J+W0mRH6Hvi+k50M4Jul2VRQ==",
+      "dev": true,
+      "dependencies": {
+        "ini": "^1.3.4",
+        "proto-list": "~1.2.1"
+      }
+    },
+    "node_modules/config-chain/node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+      "dev": true
+    },
     "node_modules/connect-history-api-fallback": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/connect-history-api-fallback/-/connect-history-api-fallback-2.0.0.tgz",
@@ -11106,12 +11480,30 @@
       }
     },
     "node_modules/crypto-random-string": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-2.0.0.tgz",
-      "integrity": "sha512-v1plID3y9r/lPhviJ1wrXpLeyUIGAZ2SHNYTEapm7/8A9nLPoyvVp3RK/EPFqn5kEznyWgYZNsRtYYIWbuG8KA==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-4.0.0.tgz",
+      "integrity": "sha512-x8dy3RnvYdlUcPOjkEHqozhiwzKNSq7GcPuXFbnyMOCHxX8V3OgIg/pYuabl2sbUPfIJaeAQB7PMOK8DFIdoRA==",
+      "dev": true,
+      "dependencies": {
+        "type-fest": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/crypto-random-string/node_modules/type-fest": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-1.4.0.tgz",
+      "integrity": "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==",
       "dev": true,
       "engines": {
-        "node": ">=8"
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/css": {
@@ -18752,6 +19144,12 @@
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "dev": true
     },
+    "node_modules/lodash-es": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.18.1.tgz",
+      "integrity": "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==",
+      "dev": true
+    },
     "node_modules/lodash.capitalize": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/lodash.capitalize/-/lodash.capitalize-4.2.1.tgz",
@@ -20026,27 +20424,28 @@
       }
     },
     "node_modules/npm": {
-      "version": "8.12.1",
-      "resolved": "https://registry.npmjs.org/npm/-/npm-8.12.1.tgz",
-      "integrity": "sha512-0yOlhfgu1UzP6UijnaFuIS2bES2H9D90EA5OVsf2iOZw7VBrjntXKEwKfCaFA6vMVWkCP8qnPwCxxPdnDVwlNw==",
+      "version": "9.9.4",
+      "resolved": "https://registry.npmjs.org/npm/-/npm-9.9.4.tgz",
+      "integrity": "sha512-NzcQiLpqDuLhavdyJ2J3tGJ/ni/ebcqHVFZkv1C4/6lblraUPbPgCJ4Vhb4oa3FFhRa2Yj9gA58jGH/ztKueNQ==",
       "bundleDependencies": [
         "@isaacs/string-locale-compare",
         "@npmcli/arborist",
-        "@npmcli/ci-detect",
         "@npmcli/config",
         "@npmcli/fs",
         "@npmcli/map-workspaces",
         "@npmcli/package-json",
+        "@npmcli/promise-spawn",
         "@npmcli/run-script",
         "abbrev",
         "archy",
         "cacache",
         "chalk",
-        "chownr",
+        "ci-info",
         "cli-columns",
         "cli-table3",
         "columnify",
         "fastest-levenshtein",
+        "fs-minipass",
         "glob",
         "graceful-fs",
         "hosted-git-info",
@@ -20066,13 +20465,13 @@
         "libnpmteam",
         "libnpmversion",
         "make-fetch-happen",
+        "minimatch",
         "minipass",
         "minipass-pipeline",
-        "mkdirp",
-        "mkdirp-infer-owner",
         "ms",
         "node-gyp",
         "nopt",
+        "normalize-package-data",
         "npm-audit-report",
         "npm-install-checks",
         "npm-package-arg",
@@ -20081,18 +20480,17 @@
         "npm-registry-fetch",
         "npm-user-validate",
         "npmlog",
-        "opener",
+        "p-map",
         "pacote",
         "parse-conflict-json",
         "proc-log",
         "qrcode-terminal",
         "read",
-        "read-package-json",
-        "read-package-json-fast",
-        "readdir-scoped-modules",
-        "rimraf",
         "semver",
+        "sigstore",
+        "spdx-expression-parse",
         "ssri",
+        "supports-color",
         "tar",
         "text-table",
         "tiny-relative-date",
@@ -20104,82 +20502,82 @@
       "dev": true,
       "dependencies": {
         "@isaacs/string-locale-compare": "^1.1.0",
-        "@npmcli/arborist": "^5.0.4",
-        "@npmcli/ci-detect": "^2.0.0",
-        "@npmcli/config": "^4.1.0",
-        "@npmcli/fs": "^2.1.0",
-        "@npmcli/map-workspaces": "^2.0.3",
-        "@npmcli/package-json": "^2.0.0",
-        "@npmcli/run-script": "^3.0.1",
-        "abbrev": "~1.1.1",
+        "@npmcli/arborist": "^6.5.0",
+        "@npmcli/config": "^6.4.0",
+        "@npmcli/fs": "^3.1.0",
+        "@npmcli/map-workspaces": "^3.0.4",
+        "@npmcli/package-json": "^4.0.1",
+        "@npmcli/promise-spawn": "^6.0.2",
+        "@npmcli/run-script": "^6.0.2",
+        "abbrev": "^2.0.0",
         "archy": "~1.0.0",
-        "cacache": "^16.1.0",
-        "chalk": "^4.1.2",
-        "chownr": "^2.0.0",
+        "cacache": "^17.1.4",
+        "chalk": "^5.3.0",
+        "ci-info": "^4.0.0",
         "cli-columns": "^4.0.0",
-        "cli-table3": "^0.6.2",
+        "cli-table3": "^0.6.3",
         "columnify": "^1.6.0",
-        "fastest-levenshtein": "^1.0.12",
-        "glob": "^8.0.1",
-        "graceful-fs": "^4.2.10",
-        "hosted-git-info": "^5.0.0",
-        "ini": "^3.0.0",
-        "init-package-json": "^3.0.2",
+        "fastest-levenshtein": "^1.0.16",
+        "fs-minipass": "^3.0.3",
+        "glob": "^10.3.10",
+        "graceful-fs": "^4.2.11",
+        "hosted-git-info": "^6.1.3",
+        "ini": "^4.1.1",
+        "init-package-json": "^5.0.0",
         "is-cidr": "^4.0.2",
-        "json-parse-even-better-errors": "^2.3.1",
-        "libnpmaccess": "^6.0.2",
-        "libnpmdiff": "^4.0.2",
-        "libnpmexec": "^4.0.2",
-        "libnpmfund": "^3.0.1",
-        "libnpmhook": "^8.0.2",
-        "libnpmorg": "^4.0.2",
-        "libnpmpack": "^4.0.2",
-        "libnpmpublish": "^6.0.2",
-        "libnpmsearch": "^5.0.2",
-        "libnpmteam": "^4.0.2",
-        "libnpmversion": "^3.0.1",
-        "make-fetch-happen": "^10.1.6",
-        "minipass": "^3.1.6",
+        "json-parse-even-better-errors": "^3.0.1",
+        "libnpmaccess": "^7.0.2",
+        "libnpmdiff": "^5.0.20",
+        "libnpmexec": "^6.0.4",
+        "libnpmfund": "^4.2.1",
+        "libnpmhook": "^9.0.3",
+        "libnpmorg": "^5.0.4",
+        "libnpmpack": "^5.0.20",
+        "libnpmpublish": "^7.5.1",
+        "libnpmsearch": "^6.0.2",
+        "libnpmteam": "^5.0.3",
+        "libnpmversion": "^4.0.2",
+        "make-fetch-happen": "^11.1.1",
+        "minimatch": "^9.0.3",
+        "minipass": "^7.0.4",
         "minipass-pipeline": "^1.2.4",
-        "mkdirp": "^1.0.4",
-        "mkdirp-infer-owner": "^2.0.0",
         "ms": "^2.1.2",
-        "node-gyp": "^9.0.0",
-        "nopt": "^5.0.0",
-        "npm-audit-report": "^3.0.0",
-        "npm-install-checks": "^5.0.0",
-        "npm-package-arg": "^9.0.2",
-        "npm-pick-manifest": "^7.0.1",
-        "npm-profile": "^6.0.3",
-        "npm-registry-fetch": "^13.1.1",
-        "npm-user-validate": "^1.0.1",
-        "npmlog": "^6.0.2",
-        "opener": "^1.5.2",
-        "pacote": "^13.6.0",
-        "parse-conflict-json": "^2.0.2",
-        "proc-log": "^2.0.1",
+        "node-gyp": "^9.4.1",
+        "nopt": "^7.2.0",
+        "normalize-package-data": "^5.0.0",
+        "npm-audit-report": "^5.0.0",
+        "npm-install-checks": "^6.3.0",
+        "npm-package-arg": "^10.1.0",
+        "npm-pick-manifest": "^8.0.2",
+        "npm-profile": "^7.0.1",
+        "npm-registry-fetch": "^14.0.5",
+        "npm-user-validate": "^2.0.0",
+        "npmlog": "^7.0.1",
+        "p-map": "^4.0.0",
+        "pacote": "^15.2.0",
+        "parse-conflict-json": "^3.0.1",
+        "proc-log": "^3.0.0",
         "qrcode-terminal": "^0.12.0",
-        "read": "~1.0.7",
-        "read-package-json": "^5.0.1",
-        "read-package-json-fast": "^2.0.3",
-        "readdir-scoped-modules": "^1.1.0",
-        "rimraf": "^3.0.2",
-        "semver": "^7.3.7",
-        "ssri": "^9.0.1",
-        "tar": "^6.1.11",
+        "read": "^2.1.0",
+        "semver": "^7.6.0",
+        "sigstore": "^1.9.0",
+        "spdx-expression-parse": "^3.0.1",
+        "ssri": "^10.0.5",
+        "supports-color": "^9.4.0",
+        "tar": "^6.2.1",
         "text-table": "~0.2.0",
         "tiny-relative-date": "^1.3.0",
-        "treeverse": "^2.0.0",
-        "validate-npm-package-name": "^4.0.0",
-        "which": "^2.0.2",
-        "write-file-atomic": "^4.0.1"
+        "treeverse": "^3.0.0",
+        "validate-npm-package-name": "^5.0.0",
+        "which": "^3.0.1",
+        "write-file-atomic": "^5.0.1"
       },
       "bin": {
         "npm": "bin/npm-cli.js",
         "npx": "bin/npx-cli.js"
       },
       "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16"
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
     "node_modules/npm-bundled": {
@@ -20515,6 +20913,73 @@
       "inBundle": true,
       "license": "MIT"
     },
+    "node_modules/npm/node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/npm/node_modules/@isaacs/cliui/node_modules/ansi-regex": {
+      "version": "6.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/npm/node_modules/@isaacs/cliui/node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/@isaacs/cliui/node_modules/string-width": {
+      "version": "5.1.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/npm/node_modules/@isaacs/cliui/node_modules/strip-ansi": {
+      "version": "7.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
     "node_modules/npm/node_modules/@isaacs/string-locale-compare": {
       "version": "1.1.0",
       "dev": true,
@@ -20522,83 +20987,73 @@
       "license": "ISC"
     },
     "node_modules/npm/node_modules/@npmcli/arborist": {
-      "version": "5.2.1",
+      "version": "6.5.1",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
         "@isaacs/string-locale-compare": "^1.1.0",
-        "@npmcli/installed-package-contents": "^1.0.7",
-        "@npmcli/map-workspaces": "^2.0.3",
-        "@npmcli/metavuln-calculator": "^3.0.1",
-        "@npmcli/move-file": "^2.0.0",
-        "@npmcli/name-from-folder": "^1.0.1",
-        "@npmcli/node-gyp": "^2.0.0",
-        "@npmcli/package-json": "^2.0.0",
-        "@npmcli/run-script": "^3.0.0",
-        "bin-links": "^3.0.0",
-        "cacache": "^16.0.6",
+        "@npmcli/fs": "^3.1.0",
+        "@npmcli/installed-package-contents": "^2.0.2",
+        "@npmcli/map-workspaces": "^3.0.2",
+        "@npmcli/metavuln-calculator": "^5.0.0",
+        "@npmcli/name-from-folder": "^2.0.0",
+        "@npmcli/node-gyp": "^3.0.0",
+        "@npmcli/package-json": "^4.0.0",
+        "@npmcli/query": "^3.1.0",
+        "@npmcli/run-script": "^6.0.0",
+        "bin-links": "^4.0.1",
+        "cacache": "^17.0.4",
         "common-ancestor-path": "^1.0.1",
-        "json-parse-even-better-errors": "^2.3.1",
+        "hosted-git-info": "^6.1.1",
+        "json-parse-even-better-errors": "^3.0.0",
         "json-stringify-nice": "^1.1.4",
-        "mkdirp": "^1.0.4",
-        "mkdirp-infer-owner": "^2.0.0",
-        "nopt": "^5.0.0",
-        "npm-install-checks": "^5.0.0",
-        "npm-package-arg": "^9.0.0",
-        "npm-pick-manifest": "^7.0.0",
-        "npm-registry-fetch": "^13.0.0",
-        "npmlog": "^6.0.2",
-        "pacote": "^13.0.5",
-        "parse-conflict-json": "^2.0.1",
-        "proc-log": "^2.0.0",
+        "minimatch": "^9.0.0",
+        "nopt": "^7.0.0",
+        "npm-install-checks": "^6.2.0",
+        "npm-package-arg": "^10.1.0",
+        "npm-pick-manifest": "^8.0.1",
+        "npm-registry-fetch": "^14.0.3",
+        "npmlog": "^7.0.1",
+        "pacote": "^15.0.8",
+        "parse-conflict-json": "^3.0.0",
+        "proc-log": "^3.0.0",
         "promise-all-reject-late": "^1.0.0",
-        "promise-call-limit": "^1.0.1",
-        "read-package-json-fast": "^2.0.2",
-        "readdir-scoped-modules": "^1.1.0",
-        "rimraf": "^3.0.2",
+        "promise-call-limit": "^1.0.2",
+        "read-package-json-fast": "^3.0.2",
         "semver": "^7.3.7",
-        "ssri": "^9.0.0",
-        "treeverse": "^2.0.0",
-        "walk-up-path": "^1.0.0"
+        "ssri": "^10.0.1",
+        "treeverse": "^3.0.0",
+        "walk-up-path": "^3.0.1"
       },
       "bin": {
         "arborist": "bin/index.js"
       },
       "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-      }
-    },
-    "node_modules/npm/node_modules/@npmcli/ci-detect": {
-      "version": "2.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16"
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
     "node_modules/npm/node_modules/@npmcli/config": {
-      "version": "4.1.0",
+      "version": "6.4.1",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/map-workspaces": "^2.0.2",
-        "ini": "^3.0.0",
-        "mkdirp-infer-owner": "^2.0.0",
-        "nopt": "^5.0.0",
-        "proc-log": "^2.0.0",
-        "read-package-json-fast": "^2.0.3",
+        "@npmcli/map-workspaces": "^3.0.2",
+        "ci-info": "^4.0.0",
+        "ini": "^4.1.0",
+        "nopt": "^7.0.0",
+        "proc-log": "^3.0.0",
+        "read-package-json-fast": "^3.0.2",
         "semver": "^7.3.5",
-        "walk-up-path": "^1.0.0"
+        "walk-up-path": "^3.0.1"
       },
       "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
     "node_modules/npm/node_modules/@npmcli/disparity-colors": {
-      "version": "2.0.0",
+      "version": "3.0.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -20606,90 +21061,88 @@
         "ansi-styles": "^4.3.0"
       },
       "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
     "node_modules/npm/node_modules/@npmcli/fs": {
-      "version": "2.1.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "@gar/promisify": "^1.1.3",
-        "semver": "^7.3.5"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-      }
-    },
-    "node_modules/npm/node_modules/@npmcli/git": {
-      "version": "3.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "@npmcli/promise-spawn": "^3.0.0",
-        "lru-cache": "^7.4.4",
-        "mkdirp": "^1.0.4",
-        "npm-pick-manifest": "^7.0.0",
-        "proc-log": "^2.0.0",
-        "promise-inflight": "^1.0.1",
-        "promise-retry": "^2.0.1",
-        "semver": "^7.3.5",
-        "which": "^2.0.2"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-      }
-    },
-    "node_modules/npm/node_modules/@npmcli/installed-package-contents": {
-      "version": "1.0.7",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "npm-bundled": "^1.1.1",
-        "npm-normalize-package-bin": "^1.0.1"
-      },
-      "bin": {
-        "installed-package-contents": "index.js"
-      },
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/npm/node_modules/@npmcli/map-workspaces": {
-      "version": "2.0.3",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "@npmcli/name-from-folder": "^1.0.1",
-        "glob": "^8.0.1",
-        "minimatch": "^5.0.1",
-        "read-package-json-fast": "^2.0.3"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-      }
-    },
-    "node_modules/npm/node_modules/@npmcli/metavuln-calculator": {
       "version": "3.1.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "cacache": "^16.0.0",
-        "json-parse-even-better-errors": "^2.3.1",
-        "pacote": "^13.0.3",
         "semver": "^7.3.5"
       },
       "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/@npmcli/git": {
+      "version": "4.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "@npmcli/promise-spawn": "^6.0.0",
+        "lru-cache": "^7.4.4",
+        "npm-pick-manifest": "^8.0.0",
+        "proc-log": "^3.0.0",
+        "promise-inflight": "^1.0.1",
+        "promise-retry": "^2.0.1",
+        "semver": "^7.3.5",
+        "which": "^3.0.0"
+      },
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/@npmcli/installed-package-contents": {
+      "version": "2.0.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "npm-bundled": "^3.0.0",
+        "npm-normalize-package-bin": "^3.0.0"
+      },
+      "bin": {
+        "installed-package-contents": "lib/index.js"
+      },
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/@npmcli/map-workspaces": {
+      "version": "3.0.4",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "@npmcli/name-from-folder": "^2.0.0",
+        "glob": "^10.2.2",
+        "minimatch": "^9.0.0",
+        "read-package-json-fast": "^3.0.0"
+      },
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/@npmcli/metavuln-calculator": {
+      "version": "5.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "cacache": "^17.0.0",
+        "json-parse-even-better-errors": "^3.0.0",
+        "pacote": "^15.0.0",
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
     "node_modules/npm/node_modules/@npmcli/move-file": {
-      "version": "2.0.0",
+      "version": "2.0.1",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -20702,57 +21155,137 @@
       }
     },
     "node_modules/npm/node_modules/@npmcli/name-from-folder": {
-      "version": "1.0.1",
+      "version": "2.0.0",
       "dev": true,
       "inBundle": true,
-      "license": "ISC"
+      "license": "ISC",
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
     },
     "node_modules/npm/node_modules/@npmcli/node-gyp": {
-      "version": "2.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-      }
-    },
-    "node_modules/npm/node_modules/@npmcli/package-json": {
-      "version": "2.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "json-parse-even-better-errors": "^2.3.1"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-      }
-    },
-    "node_modules/npm/node_modules/@npmcli/promise-spawn": {
       "version": "3.0.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
-      "dependencies": {
-        "infer-owner": "^1.0.4"
-      },
       "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
-    "node_modules/npm/node_modules/@npmcli/run-script": {
-      "version": "3.0.2",
+    "node_modules/npm/node_modules/@npmcli/package-json": {
+      "version": "4.0.1",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/node-gyp": "^2.0.0",
-        "@npmcli/promise-spawn": "^3.0.0",
-        "node-gyp": "^9.0.0",
-        "read-package-json-fast": "^2.0.3"
+        "@npmcli/git": "^4.1.0",
+        "glob": "^10.2.2",
+        "hosted-git-info": "^6.1.1",
+        "json-parse-even-better-errors": "^3.0.0",
+        "normalize-package-data": "^5.0.0",
+        "proc-log": "^3.0.0",
+        "semver": "^7.5.3"
       },
       "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/@npmcli/promise-spawn": {
+      "version": "6.0.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "which": "^3.0.0"
+      },
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/@npmcli/query": {
+      "version": "3.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "postcss-selector-parser": "^6.0.10"
+      },
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/@npmcli/run-script": {
+      "version": "6.0.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "@npmcli/node-gyp": "^3.0.0",
+        "@npmcli/promise-spawn": "^6.0.0",
+        "node-gyp": "^9.0.0",
+        "read-package-json-fast": "^3.0.0",
+        "which": "^3.0.0"
+      },
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/npm/node_modules/@sigstore/bundle": {
+      "version": "1.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@sigstore/protobuf-specs": "^0.2.0"
+      },
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/@sigstore/protobuf-specs": {
+      "version": "0.2.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/@sigstore/sign": {
+      "version": "1.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@sigstore/bundle": "^1.1.0",
+        "@sigstore/protobuf-specs": "^0.2.0",
+        "make-fetch-happen": "^11.0.1"
+      },
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/@sigstore/tuf": {
+      "version": "1.0.3",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@sigstore/protobuf-specs": "^0.2.0",
+        "tuf-js": "^1.1.7"
+      },
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
     "node_modules/npm/node_modules/@tootallnate/once": {
@@ -20764,11 +21297,36 @@
         "node": ">= 10"
       }
     },
-    "node_modules/npm/node_modules/abbrev": {
-      "version": "1.1.1",
+    "node_modules/npm/node_modules/@tufjs/canonical-json": {
+      "version": "1.0.0",
       "dev": true,
       "inBundle": true,
-      "license": "ISC"
+      "license": "MIT",
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/@tufjs/models": {
+      "version": "1.0.4",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "@tufjs/canonical-json": "1.0.0",
+        "minimatch": "^9.0.0"
+      },
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/abbrev": {
+      "version": "2.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
     },
     "node_modules/npm/node_modules/agent-base": {
       "version": "6.0.2",
@@ -20783,13 +21341,11 @@
       }
     },
     "node_modules/npm/node_modules/agentkeepalive": {
-      "version": "4.2.1",
+      "version": "4.5.0",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
-        "debug": "^4.1.0",
-        "depd": "^1.1.2",
         "humanize-ms": "^1.2.1"
       },
       "engines": {
@@ -20846,23 +21402,13 @@
       "license": "MIT"
     },
     "node_modules/npm/node_modules/are-we-there-yet": {
-      "version": "3.0.0",
+      "version": "4.0.2",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
-      "dependencies": {
-        "delegates": "^1.0.0",
-        "readable-stream": "^3.6.0"
-      },
       "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16"
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
-    },
-    "node_modules/npm/node_modules/asap": {
-      "version": "2.0.6",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT"
     },
     "node_modules/npm/node_modules/balanced-match": {
       "version": "1.0.2",
@@ -20871,20 +21417,18 @@
       "license": "MIT"
     },
     "node_modules/npm/node_modules/bin-links": {
-      "version": "3.0.1",
+      "version": "4.0.3",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "cmd-shim": "^5.0.0",
-        "mkdirp-infer-owner": "^2.0.0",
-        "npm-normalize-package-bin": "^1.0.0",
-        "read-cmd-shim": "^3.0.0",
-        "rimraf": "^3.0.0",
-        "write-file-atomic": "^4.0.0"
+        "cmd-shim": "^6.0.0",
+        "npm-normalize-package-bin": "^3.0.0",
+        "read-cmd-shim": "^4.0.0",
+        "write-file-atomic": "^5.0.0"
       },
       "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
     "node_modules/npm/node_modules/binary-extensions": {
@@ -20915,45 +21459,35 @@
       }
     },
     "node_modules/npm/node_modules/cacache": {
-      "version": "16.1.0",
+      "version": "17.1.4",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/fs": "^2.1.0",
-        "@npmcli/move-file": "^2.0.0",
-        "chownr": "^2.0.0",
-        "fs-minipass": "^2.1.0",
-        "glob": "^8.0.1",
-        "infer-owner": "^1.0.4",
+        "@npmcli/fs": "^3.1.0",
+        "fs-minipass": "^3.0.0",
+        "glob": "^10.2.2",
         "lru-cache": "^7.7.1",
-        "minipass": "^3.1.6",
+        "minipass": "^7.0.3",
         "minipass-collect": "^1.0.2",
         "minipass-flush": "^1.0.5",
         "minipass-pipeline": "^1.2.4",
-        "mkdirp": "^1.0.4",
         "p-map": "^4.0.0",
-        "promise-inflight": "^1.0.1",
-        "rimraf": "^3.0.2",
-        "ssri": "^9.0.0",
+        "ssri": "^10.0.0",
         "tar": "^6.1.11",
-        "unique-filename": "^1.1.1"
+        "unique-filename": "^3.0.0"
       },
       "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
     "node_modules/npm/node_modules/chalk": {
-      "version": "4.1.2",
+      "version": "5.3.0",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
       "engines": {
-        "node": ">=10"
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
@@ -20966,6 +21500,21 @@
       "license": "ISC",
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/npm/node_modules/ci-info": {
+      "version": "4.0.0",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/sibiraj-s"
+        }
+      ],
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/npm/node_modules/cidr-regex": {
@@ -21003,7 +21552,7 @@
       }
     },
     "node_modules/npm/node_modules/cli-table3": {
-      "version": "0.6.2",
+      "version": "0.6.3",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -21027,15 +21576,12 @@
       }
     },
     "node_modules/npm/node_modules/cmd-shim": {
-      "version": "5.0.0",
+      "version": "6.0.2",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
-      "dependencies": {
-        "mkdirp-infer-owner": "^2.0.0"
-      },
       "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
     "node_modules/npm/node_modules/color-convert": {
@@ -21096,13 +21642,54 @@
       "inBundle": true,
       "license": "ISC"
     },
-    "node_modules/npm/node_modules/debug": {
-      "version": "4.3.4",
+    "node_modules/npm/node_modules/cross-spawn": {
+      "version": "7.0.6",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
-        "ms": "2.1.2"
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/npm/node_modules/cross-spawn/node_modules/which": {
+      "version": "2.0.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/npm/node_modules/cssesc": {
+      "version": "3.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "bin": {
+        "cssesc": "bin/cssesc"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/npm/node_modules/debug": {
+      "version": "4.3.7",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
       },
       "engines": {
         "node": ">=6.0"
@@ -21113,28 +21700,16 @@
         }
       }
     },
-    "node_modules/npm/node_modules/debug/node_modules/ms": {
-      "version": "2.1.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/npm/node_modules/debuglog": {
-      "version": "1.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/npm/node_modules/defaults": {
-      "version": "1.0.3",
+      "version": "1.0.4",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "clone": "^1.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/npm/node_modules/delegates": {
@@ -21143,33 +21718,20 @@
       "inBundle": true,
       "license": "MIT"
     },
-    "node_modules/npm/node_modules/depd": {
-      "version": "1.1.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/npm/node_modules/dezalgo": {
-      "version": "1.0.4",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "asap": "^2.0.0",
-        "wrappy": "1"
-      }
-    },
     "node_modules/npm/node_modules/diff": {
-      "version": "5.0.0",
+      "version": "5.2.0",
       "dev": true,
       "inBundle": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.3.1"
       }
+    },
+    "node_modules/npm/node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
     },
     "node_modules/npm/node_modules/emoji-regex": {
       "version": "8.0.0",
@@ -21202,22 +21764,47 @@
       "inBundle": true,
       "license": "MIT"
     },
-    "node_modules/npm/node_modules/fastest-levenshtein": {
-      "version": "1.0.12",
+    "node_modules/npm/node_modules/exponential-backoff": {
+      "version": "3.1.1",
       "dev": true,
       "inBundle": true,
-      "license": "MIT"
+      "license": "Apache-2.0"
     },
-    "node_modules/npm/node_modules/fs-minipass": {
-      "version": "2.1.0",
+    "node_modules/npm/node_modules/fastest-levenshtein": {
+      "version": "1.0.16",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4.9.1"
+      }
+    },
+    "node_modules/npm/node_modules/foreground-child": {
+      "version": "3.1.1",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "minipass": "^3.0.0"
+        "cross-spawn": "^7.0.0",
+        "signal-exit": "^4.0.1"
       },
       "engines": {
-        "node": ">= 8"
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/npm/node_modules/fs-minipass": {
+      "version": "3.0.3",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^7.0.3"
+      },
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
     "node_modules/npm/node_modules/fs.realpath": {
@@ -21227,13 +21814,16 @@
       "license": "ISC"
     },
     "node_modules/npm/node_modules/function-bind": {
-      "version": "1.1.1",
+      "version": "1.1.2",
       "dev": true,
       "inBundle": true,
-      "license": "MIT"
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/npm/node_modules/gauge": {
-      "version": "4.0.4",
+      "version": "5.0.1",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -21242,60 +21832,42 @@
         "color-support": "^1.1.3",
         "console-control-strings": "^1.1.0",
         "has-unicode": "^2.0.1",
-        "signal-exit": "^3.0.7",
+        "signal-exit": "^4.0.1",
         "string-width": "^4.2.3",
         "strip-ansi": "^6.0.1",
         "wide-align": "^1.1.5"
       },
       "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
     "node_modules/npm/node_modules/glob": {
-      "version": "8.0.3",
+      "version": "10.3.10",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^5.0.1",
-        "once": "^1.3.0"
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^2.3.5",
+        "minimatch": "^9.0.1",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0",
+        "path-scurry": "^1.10.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=16 || 14 >=14.17"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/npm/node_modules/graceful-fs": {
-      "version": "4.2.10",
+      "version": "4.2.11",
       "dev": true,
       "inBundle": true,
       "license": "ISC"
-    },
-    "node_modules/npm/node_modules/has": {
-      "version": "1.0.3",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "function-bind": "^1.1.1"
-      },
-      "engines": {
-        "node": ">= 0.4.0"
-      }
-    },
-    "node_modules/npm/node_modules/has-flag": {
-      "version": "4.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
     },
     "node_modules/npm/node_modules/has-unicode": {
       "version": "2.0.1",
@@ -21303,8 +21875,20 @@
       "inBundle": true,
       "license": "ISC"
     },
+    "node_modules/npm/node_modules/hasown": {
+      "version": "2.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/npm/node_modules/hosted-git-info": {
-      "version": "5.0.0",
+      "version": "6.1.3",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -21312,11 +21896,11 @@
         "lru-cache": "^7.5.1"
       },
       "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16"
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
     "node_modules/npm/node_modules/http-cache-semantics": {
-      "version": "4.1.0",
+      "version": "4.1.1",
       "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause"
@@ -21371,15 +21955,15 @@
       }
     },
     "node_modules/npm/node_modules/ignore-walk": {
-      "version": "5.0.1",
+      "version": "6.0.4",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "minimatch": "^5.0.1"
+        "minimatch": "^9.0.0"
       },
       "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
     "node_modules/npm/node_modules/imurmurhash": {
@@ -21423,37 +22007,50 @@
       "license": "ISC"
     },
     "node_modules/npm/node_modules/ini": {
-      "version": "3.0.0",
+      "version": "4.1.1",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
     "node_modules/npm/node_modules/init-package-json": {
-      "version": "3.0.2",
+      "version": "5.0.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "npm-package-arg": "^9.0.1",
-        "promzard": "^0.3.0",
-        "read": "^1.0.7",
-        "read-package-json": "^5.0.0",
+        "npm-package-arg": "^10.0.0",
+        "promzard": "^1.0.0",
+        "read": "^2.0.0",
+        "read-package-json": "^6.0.0",
         "semver": "^7.3.5",
         "validate-npm-package-license": "^3.0.4",
-        "validate-npm-package-name": "^4.0.0"
+        "validate-npm-package-name": "^5.0.0"
       },
       "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
-    "node_modules/npm/node_modules/ip": {
-      "version": "1.1.8",
+    "node_modules/npm/node_modules/ip-address": {
+      "version": "9.0.5",
       "dev": true,
       "inBundle": true,
-      "license": "MIT"
+      "license": "MIT",
+      "dependencies": {
+        "jsbn": "1.1.0",
+        "sprintf-js": "^1.1.3"
+      },
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/npm/node_modules/ip-address/node_modules/sprintf-js": {
+      "version": "1.1.3",
+      "dev": true,
+      "inBundle": true,
+      "license": "BSD-3-Clause"
     },
     "node_modules/npm/node_modules/ip-regex": {
       "version": "4.3.0",
@@ -21477,12 +22074,12 @@
       }
     },
     "node_modules/npm/node_modules/is-core-module": {
-      "version": "2.9.0",
+      "version": "2.13.1",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
-        "has": "^1.0.3"
+        "hasown": "^2.0.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -21509,11 +22106,38 @@
       "inBundle": true,
       "license": "ISC"
     },
-    "node_modules/npm/node_modules/json-parse-even-better-errors": {
-      "version": "2.3.1",
+    "node_modules/npm/node_modules/jackspeak": {
+      "version": "2.3.6",
+      "dev": true,
+      "inBundle": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
+    "node_modules/npm/node_modules/jsbn": {
+      "version": "1.1.0",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
+    },
+    "node_modules/npm/node_modules/json-parse-even-better-errors": {
+      "version": "3.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
     },
     "node_modules/npm/node_modules/json-stringify-nice": {
       "version": "1.1.4",
@@ -21534,185 +22158,187 @@
       "license": "MIT"
     },
     "node_modules/npm/node_modules/just-diff": {
-      "version": "5.0.2",
+      "version": "6.0.2",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/just-diff-apply": {
-      "version": "5.2.0",
+      "version": "5.5.0",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/libnpmaccess": {
+      "version": "7.0.3",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "npm-package-arg": "^10.1.0",
+        "npm-registry-fetch": "^14.0.3"
+      },
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/libnpmdiff": {
+      "version": "5.0.21",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "@npmcli/arborist": "^6.5.0",
+        "@npmcli/disparity-colors": "^3.0.0",
+        "@npmcli/installed-package-contents": "^2.0.2",
+        "binary-extensions": "^2.2.0",
+        "diff": "^5.1.0",
+        "minimatch": "^9.0.0",
+        "npm-package-arg": "^10.1.0",
+        "pacote": "^15.0.8",
+        "tar": "^6.1.13"
+      },
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/libnpmexec": {
+      "version": "6.0.5",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "@npmcli/arborist": "^6.5.0",
+        "@npmcli/run-script": "^6.0.0",
+        "ci-info": "^4.0.0",
+        "npm-package-arg": "^10.1.0",
+        "npmlog": "^7.0.1",
+        "pacote": "^15.0.8",
+        "proc-log": "^3.0.0",
+        "read": "^2.0.0",
+        "read-package-json-fast": "^3.0.2",
+        "semver": "^7.3.7",
+        "walk-up-path": "^3.0.1"
+      },
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/libnpmfund": {
+      "version": "4.2.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "@npmcli/arborist": "^6.5.0"
+      },
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/libnpmhook": {
+      "version": "9.0.4",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "aproba": "^2.0.0",
+        "npm-registry-fetch": "^14.0.3"
+      },
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/libnpmorg": {
+      "version": "5.0.5",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "aproba": "^2.0.0",
+        "npm-registry-fetch": "^14.0.3"
+      },
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/libnpmpack": {
+      "version": "5.0.21",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "@npmcli/arborist": "^6.5.0",
+        "@npmcli/run-script": "^6.0.0",
+        "npm-package-arg": "^10.1.0",
+        "pacote": "^15.0.8"
+      },
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/libnpmpublish": {
+      "version": "7.5.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "ci-info": "^4.0.0",
+        "normalize-package-data": "^5.0.0",
+        "npm-package-arg": "^10.1.0",
+        "npm-registry-fetch": "^14.0.3",
+        "proc-log": "^3.0.0",
+        "semver": "^7.3.7",
+        "sigstore": "^1.4.0",
+        "ssri": "^10.0.1"
+      },
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/libnpmsearch": {
       "version": "6.0.3",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "aproba": "^2.0.0",
-        "minipass": "^3.1.1",
-        "npm-package-arg": "^9.0.1",
-        "npm-registry-fetch": "^13.0.0"
+        "npm-registry-fetch": "^14.0.3"
       },
       "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-      }
-    },
-    "node_modules/npm/node_modules/libnpmdiff": {
-      "version": "4.0.3",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "@npmcli/disparity-colors": "^2.0.0",
-        "@npmcli/installed-package-contents": "^1.0.7",
-        "binary-extensions": "^2.2.0",
-        "diff": "^5.0.0",
-        "minimatch": "^5.0.1",
-        "npm-package-arg": "^9.0.1",
-        "pacote": "^13.0.5",
-        "tar": "^6.1.0"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-      }
-    },
-    "node_modules/npm/node_modules/libnpmexec": {
-      "version": "4.0.6",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "@npmcli/arborist": "^5.0.0",
-        "@npmcli/ci-detect": "^2.0.0",
-        "@npmcli/run-script": "^3.0.0",
-        "chalk": "^4.1.0",
-        "mkdirp-infer-owner": "^2.0.0",
-        "npm-package-arg": "^9.0.1",
-        "npmlog": "^6.0.2",
-        "pacote": "^13.0.5",
-        "proc-log": "^2.0.0",
-        "read": "^1.0.7",
-        "read-package-json-fast": "^2.0.2",
-        "walk-up-path": "^1.0.0"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-      }
-    },
-    "node_modules/npm/node_modules/libnpmfund": {
-      "version": "3.0.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "@npmcli/arborist": "^5.0.0"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-      }
-    },
-    "node_modules/npm/node_modules/libnpmhook": {
-      "version": "8.0.3",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "aproba": "^2.0.0",
-        "npm-registry-fetch": "^13.0.0"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-      }
-    },
-    "node_modules/npm/node_modules/libnpmorg": {
-      "version": "4.0.3",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "aproba": "^2.0.0",
-        "npm-registry-fetch": "^13.0.0"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-      }
-    },
-    "node_modules/npm/node_modules/libnpmpack": {
-      "version": "4.1.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "@npmcli/run-script": "^3.0.0",
-        "npm-package-arg": "^9.0.1",
-        "pacote": "^13.5.0"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-      }
-    },
-    "node_modules/npm/node_modules/libnpmpublish": {
-      "version": "6.0.4",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "normalize-package-data": "^4.0.0",
-        "npm-package-arg": "^9.0.1",
-        "npm-registry-fetch": "^13.0.0",
-        "semver": "^7.3.7",
-        "ssri": "^9.0.0"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-      }
-    },
-    "node_modules/npm/node_modules/libnpmsearch": {
-      "version": "5.0.3",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "npm-registry-fetch": "^13.0.0"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
     "node_modules/npm/node_modules/libnpmteam": {
-      "version": "4.0.3",
+      "version": "5.0.4",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
         "aproba": "^2.0.0",
-        "npm-registry-fetch": "^13.0.0"
+        "npm-registry-fetch": "^14.0.3"
       },
       "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
     "node_modules/npm/node_modules/libnpmversion": {
-      "version": "3.0.4",
+      "version": "4.0.3",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/git": "^3.0.0",
-        "@npmcli/run-script": "^3.0.0",
-        "json-parse-even-better-errors": "^2.3.1",
-        "proc-log": "^2.0.0",
+        "@npmcli/git": "^4.0.1",
+        "@npmcli/run-script": "^6.0.0",
+        "json-parse-even-better-errors": "^3.0.0",
+        "proc-log": "^3.0.0",
         "semver": "^7.3.7"
       },
       "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
     "node_modules/npm/node_modules/lru-cache": {
-      "version": "7.9.0",
+      "version": "7.18.3",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -21721,34 +22347,42 @@
       }
     },
     "node_modules/npm/node_modules/make-fetch-happen": {
-      "version": "10.1.6",
+      "version": "11.1.1",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
         "agentkeepalive": "^4.2.1",
-        "cacache": "^16.1.0",
-        "http-cache-semantics": "^4.1.0",
+        "cacache": "^17.0.0",
+        "http-cache-semantics": "^4.1.1",
         "http-proxy-agent": "^5.0.0",
         "https-proxy-agent": "^5.0.0",
         "is-lambda": "^1.0.1",
         "lru-cache": "^7.7.1",
-        "minipass": "^3.1.6",
-        "minipass-collect": "^1.0.2",
-        "minipass-fetch": "^2.0.3",
+        "minipass": "^5.0.0",
+        "minipass-fetch": "^3.0.0",
         "minipass-flush": "^1.0.5",
         "minipass-pipeline": "^1.2.4",
         "negotiator": "^0.6.3",
         "promise-retry": "^2.0.1",
-        "socks-proxy-agent": "^6.1.1",
-        "ssri": "^9.0.0"
+        "socks-proxy-agent": "^7.0.0",
+        "ssri": "^10.0.0"
       },
       "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/make-fetch-happen/node_modules/minipass": {
+      "version": "5.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/npm/node_modules/minimatch": {
-      "version": "5.1.0",
+      "version": "9.0.3",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -21756,19 +22390,19 @@
         "brace-expansion": "^2.0.1"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/npm/node_modules/minipass": {
-      "version": "3.1.6",
+      "version": "7.0.4",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
       "engines": {
-        "node": ">=8"
+        "node": ">=16 || 14 >=14.17"
       }
     },
     "node_modules/npm/node_modules/minipass-collect": {
@@ -21783,18 +22417,30 @@
         "node": ">= 8"
       }
     },
+    "node_modules/npm/node_modules/minipass-collect/node_modules/minipass": {
+      "version": "3.3.6",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/npm/node_modules/minipass-fetch": {
-      "version": "2.1.0",
+      "version": "3.0.4",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
-        "minipass": "^3.1.6",
+        "minipass": "^7.0.3",
         "minipass-sized": "^1.0.3",
         "minizlib": "^2.1.2"
       },
       "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       },
       "optionalDependencies": {
         "encoding": "^0.1.13"
@@ -21812,6 +22458,18 @@
         "node": ">= 8"
       }
     },
+    "node_modules/npm/node_modules/minipass-flush/node_modules/minipass": {
+      "version": "3.3.6",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/npm/node_modules/minipass-json-stream": {
       "version": "1.0.1",
       "dev": true,
@@ -21820,6 +22478,18 @@
       "dependencies": {
         "jsonparse": "^1.3.1",
         "minipass": "^3.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/minipass-json-stream/node_modules/minipass": {
+      "version": "3.3.6",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/npm/node_modules/minipass-pipeline": {
@@ -21834,6 +22504,18 @@
         "node": ">=8"
       }
     },
+    "node_modules/npm/node_modules/minipass-pipeline/node_modules/minipass": {
+      "version": "3.3.6",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/npm/node_modules/minipass-sized": {
       "version": "1.0.3",
       "dev": true,
@@ -21841,6 +22523,18 @@
       "license": "ISC",
       "dependencies": {
         "minipass": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/npm/node_modules/minipass-sized/node_modules/minipass": {
+      "version": "3.3.6",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^4.0.0"
       },
       "engines": {
         "node": ">=8"
@@ -21859,6 +22553,18 @@
         "node": ">= 8"
       }
     },
+    "node_modules/npm/node_modules/minizlib/node_modules/minipass": {
+      "version": "3.3.6",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/npm/node_modules/mkdirp": {
       "version": "1.0.4",
       "dev": true,
@@ -21871,20 +22577,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/npm/node_modules/mkdirp-infer-owner": {
-      "version": "2.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "chownr": "^2.0.0",
-        "infer-owner": "^1.0.4",
-        "mkdirp": "^1.0.3"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/npm/node_modules/ms": {
       "version": "2.1.3",
       "dev": true,
@@ -21892,10 +22584,13 @@
       "license": "MIT"
     },
     "node_modules/npm/node_modules/mute-stream": {
-      "version": "0.0.8",
+      "version": "1.0.0",
       "dev": true,
       "inBundle": true,
-      "license": "ISC"
+      "license": "ISC",
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
     },
     "node_modules/npm/node_modules/negotiator": {
       "version": "0.6.3",
@@ -21907,16 +22602,17 @@
       }
     },
     "node_modules/npm/node_modules/node-gyp": {
-      "version": "9.0.0",
+      "version": "9.4.1",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "env-paths": "^2.2.0",
+        "exponential-backoff": "^3.1.1",
         "glob": "^7.1.4",
         "graceful-fs": "^4.2.6",
         "make-fetch-happen": "^10.0.3",
-        "nopt": "^5.0.0",
+        "nopt": "^6.0.0",
         "npmlog": "^6.0.0",
         "rimraf": "^3.0.2",
         "semver": "^7.3.5",
@@ -21927,7 +22623,39 @@
         "node-gyp": "bin/node-gyp.js"
       },
       "engines": {
-        "node": "^12.22 || ^14.13 || >=16"
+        "node": "^12.13 || ^14.13 || >=16"
+      }
+    },
+    "node_modules/npm/node_modules/node-gyp/node_modules/@npmcli/fs": {
+      "version": "2.1.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "@gar/promisify": "^1.1.3",
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/node-gyp/node_modules/abbrev": {
+      "version": "1.1.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/npm/node_modules/node-gyp/node_modules/are-we-there-yet": {
+      "version": "3.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "delegates": "^1.0.0",
+        "readable-stream": "^3.6.0"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
     },
     "node_modules/npm/node_modules/node-gyp/node_modules/brace-expansion": {
@@ -21938,6 +22666,106 @@
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/npm/node_modules/node-gyp/node_modules/cacache": {
+      "version": "16.1.3",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "@npmcli/fs": "^2.1.0",
+        "@npmcli/move-file": "^2.0.0",
+        "chownr": "^2.0.0",
+        "fs-minipass": "^2.1.0",
+        "glob": "^8.0.1",
+        "infer-owner": "^1.0.4",
+        "lru-cache": "^7.7.1",
+        "minipass": "^3.1.6",
+        "minipass-collect": "^1.0.2",
+        "minipass-flush": "^1.0.5",
+        "minipass-pipeline": "^1.2.4",
+        "mkdirp": "^1.0.4",
+        "p-map": "^4.0.0",
+        "promise-inflight": "^1.0.1",
+        "rimraf": "^3.0.2",
+        "ssri": "^9.0.0",
+        "tar": "^6.1.11",
+        "unique-filename": "^2.0.0"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/node-gyp/node_modules/cacache/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/node-gyp/node_modules/cacache/node_modules/glob": {
+      "version": "8.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^5.0.1",
+        "once": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/npm/node_modules/node-gyp/node_modules/cacache/node_modules/minimatch": {
+      "version": "5.1.6",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/npm/node_modules/node-gyp/node_modules/fs-minipass": {
+      "version": "2.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/npm/node_modules/node-gyp/node_modules/gauge": {
+      "version": "4.0.4",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "aproba": "^1.0.3 || ^2.0.0",
+        "color-support": "^1.1.3",
+        "console-control-strings": "^1.1.0",
+        "has-unicode": "^2.0.1",
+        "signal-exit": "^3.0.7",
+        "string-width": "^4.2.3",
+        "strip-ansi": "^6.0.1",
+        "wide-align": "^1.1.5"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
     },
     "node_modules/npm/node_modules/node-gyp/node_modules/glob": {
@@ -21960,6 +22788,33 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/npm/node_modules/node-gyp/node_modules/make-fetch-happen": {
+      "version": "10.2.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "agentkeepalive": "^4.2.1",
+        "cacache": "^16.1.0",
+        "http-cache-semantics": "^4.1.0",
+        "http-proxy-agent": "^5.0.0",
+        "https-proxy-agent": "^5.0.0",
+        "is-lambda": "^1.0.1",
+        "lru-cache": "^7.7.1",
+        "minipass": "^3.1.6",
+        "minipass-collect": "^1.0.2",
+        "minipass-fetch": "^2.0.3",
+        "minipass-flush": "^1.0.5",
+        "minipass-pipeline": "^1.2.4",
+        "negotiator": "^0.6.3",
+        "promise-retry": "^2.0.1",
+        "socks-proxy-agent": "^7.0.0",
+        "ssri": "^9.0.0"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
     "node_modules/npm/node_modules/node-gyp/node_modules/minimatch": {
       "version": "3.1.2",
       "dev": true,
@@ -21972,160 +22827,51 @@
         "node": "*"
       }
     },
-    "node_modules/npm/node_modules/nopt": {
-      "version": "5.0.0",
+    "node_modules/npm/node_modules/node-gyp/node_modules/minipass": {
+      "version": "3.3.6",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "abbrev": "1"
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/npm/node_modules/node-gyp/node_modules/minipass-fetch": {
+      "version": "2.1.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "minipass": "^3.1.6",
+        "minipass-sized": "^1.0.3",
+        "minizlib": "^2.1.2"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      },
+      "optionalDependencies": {
+        "encoding": "^0.1.13"
+      }
+    },
+    "node_modules/npm/node_modules/node-gyp/node_modules/nopt": {
+      "version": "6.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "abbrev": "^1.0.0"
       },
       "bin": {
         "nopt": "bin/nopt.js"
       },
       "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/npm/node_modules/normalize-package-data": {
-      "version": "4.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "hosted-git-info": "^5.0.0",
-        "is-core-module": "^2.8.1",
-        "semver": "^7.3.5",
-        "validate-npm-package-license": "^3.0.4"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16"
-      }
-    },
-    "node_modules/npm/node_modules/npm-audit-report": {
-      "version": "3.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "chalk": "^4.0.0"
-      },
-      "engines": {
         "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
     },
-    "node_modules/npm/node_modules/npm-bundled": {
-      "version": "1.1.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "npm-normalize-package-bin": "^1.0.1"
-      }
-    },
-    "node_modules/npm/node_modules/npm-install-checks": {
-      "version": "5.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "semver": "^7.1.1"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-      }
-    },
-    "node_modules/npm/node_modules/npm-normalize-package-bin": {
-      "version": "1.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC"
-    },
-    "node_modules/npm/node_modules/npm-package-arg": {
-      "version": "9.0.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "hosted-git-info": "^5.0.0",
-        "semver": "^7.3.5",
-        "validate-npm-package-name": "^4.0.0"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-      }
-    },
-    "node_modules/npm/node_modules/npm-packlist": {
-      "version": "5.1.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "glob": "^8.0.1",
-        "ignore-walk": "^5.0.1",
-        "npm-bundled": "^1.1.2",
-        "npm-normalize-package-bin": "^1.0.1"
-      },
-      "bin": {
-        "npm-packlist": "bin/index.js"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-      }
-    },
-    "node_modules/npm/node_modules/npm-pick-manifest": {
-      "version": "7.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "npm-install-checks": "^5.0.0",
-        "npm-normalize-package-bin": "^1.0.1",
-        "npm-package-arg": "^9.0.0",
-        "semver": "^7.3.5"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-      }
-    },
-    "node_modules/npm/node_modules/npm-profile": {
-      "version": "6.0.3",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "npm-registry-fetch": "^13.0.1",
-        "proc-log": "^2.0.0"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-      }
-    },
-    "node_modules/npm/node_modules/npm-registry-fetch": {
-      "version": "13.1.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "make-fetch-happen": "^10.0.6",
-        "minipass": "^3.1.6",
-        "minipass-fetch": "^2.0.3",
-        "minipass-json-stream": "^1.0.1",
-        "minizlib": "^2.1.2",
-        "npm-package-arg": "^9.0.1",
-        "proc-log": "^2.0.0"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-      }
-    },
-    "node_modules/npm/node_modules/npm-user-validate": {
-      "version": "1.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "BSD-2-Clause"
-    },
-    "node_modules/npm/node_modules/npmlog": {
+    "node_modules/npm/node_modules/node-gyp/node_modules/npmlog": {
       "version": "6.0.2",
       "dev": true,
       "inBundle": true,
@@ -22140,6 +22886,241 @@
         "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
     },
+    "node_modules/npm/node_modules/node-gyp/node_modules/signal-exit": {
+      "version": "3.0.7",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/npm/node_modules/node-gyp/node_modules/ssri": {
+      "version": "9.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^3.1.1"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/node-gyp/node_modules/unique-filename": {
+      "version": "2.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "unique-slug": "^3.0.0"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/node-gyp/node_modules/unique-slug": {
+      "version": "3.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "imurmurhash": "^0.1.4"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/node-gyp/node_modules/which": {
+      "version": "2.0.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/npm/node_modules/nopt": {
+      "version": "7.2.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "abbrev": "^2.0.0"
+      },
+      "bin": {
+        "nopt": "bin/nopt.js"
+      },
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/normalize-package-data": {
+      "version": "5.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "hosted-git-info": "^6.0.0",
+        "is-core-module": "^2.8.1",
+        "semver": "^7.3.5",
+        "validate-npm-package-license": "^3.0.4"
+      },
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/npm-audit-report": {
+      "version": "5.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/npm-bundled": {
+      "version": "3.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "npm-normalize-package-bin": "^3.0.0"
+      },
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/npm-install-checks": {
+      "version": "6.3.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "semver": "^7.1.1"
+      },
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/npm-normalize-package-bin": {
+      "version": "3.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/npm-package-arg": {
+      "version": "10.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "hosted-git-info": "^6.0.0",
+        "proc-log": "^3.0.0",
+        "semver": "^7.3.5",
+        "validate-npm-package-name": "^5.0.0"
+      },
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/npm-packlist": {
+      "version": "7.0.4",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "ignore-walk": "^6.0.0"
+      },
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/npm-pick-manifest": {
+      "version": "8.0.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "npm-install-checks": "^6.0.0",
+        "npm-normalize-package-bin": "^3.0.0",
+        "npm-package-arg": "^10.0.0",
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/npm-profile": {
+      "version": "7.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "npm-registry-fetch": "^14.0.0",
+        "proc-log": "^3.0.0"
+      },
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/npm-registry-fetch": {
+      "version": "14.0.5",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "make-fetch-happen": "^11.0.0",
+        "minipass": "^5.0.0",
+        "minipass-fetch": "^3.0.0",
+        "minipass-json-stream": "^1.0.1",
+        "minizlib": "^2.1.2",
+        "npm-package-arg": "^10.0.0",
+        "proc-log": "^3.0.0"
+      },
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/npm-registry-fetch/node_modules/minipass": {
+      "version": "5.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/npm/node_modules/npm-user-validate": {
+      "version": "2.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/npmlog": {
+      "version": "7.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "are-we-there-yet": "^4.0.0",
+        "console-control-strings": "^1.1.0",
+        "gauge": "^5.0.0",
+        "set-blocking": "^2.0.0"
+      },
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
     "node_modules/npm/node_modules/once": {
       "version": "1.4.0",
       "dev": true,
@@ -22147,15 +23128,6 @@
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
-      }
-    },
-    "node_modules/npm/node_modules/opener": {
-      "version": "1.5.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "(WTFPL OR MIT)",
-      "bin": {
-        "opener": "bin/opener-bin.js"
       }
     },
     "node_modules/npm/node_modules/p-map": {
@@ -22174,52 +23146,58 @@
       }
     },
     "node_modules/npm/node_modules/pacote": {
-      "version": "13.6.0",
+      "version": "15.2.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/git": "^3.0.0",
-        "@npmcli/installed-package-contents": "^1.0.7",
-        "@npmcli/promise-spawn": "^3.0.0",
-        "@npmcli/run-script": "^3.0.1",
-        "cacache": "^16.0.0",
-        "chownr": "^2.0.0",
-        "fs-minipass": "^2.1.0",
-        "infer-owner": "^1.0.4",
-        "minipass": "^3.1.6",
-        "mkdirp": "^1.0.4",
-        "npm-package-arg": "^9.0.0",
-        "npm-packlist": "^5.1.0",
-        "npm-pick-manifest": "^7.0.0",
-        "npm-registry-fetch": "^13.0.1",
-        "proc-log": "^2.0.0",
+        "@npmcli/git": "^4.0.0",
+        "@npmcli/installed-package-contents": "^2.0.1",
+        "@npmcli/promise-spawn": "^6.0.1",
+        "@npmcli/run-script": "^6.0.0",
+        "cacache": "^17.0.0",
+        "fs-minipass": "^3.0.0",
+        "minipass": "^5.0.0",
+        "npm-package-arg": "^10.0.0",
+        "npm-packlist": "^7.0.0",
+        "npm-pick-manifest": "^8.0.0",
+        "npm-registry-fetch": "^14.0.0",
+        "proc-log": "^3.0.0",
         "promise-retry": "^2.0.1",
-        "read-package-json": "^5.0.0",
-        "read-package-json-fast": "^2.0.3",
-        "rimraf": "^3.0.2",
-        "ssri": "^9.0.0",
+        "read-package-json": "^6.0.0",
+        "read-package-json-fast": "^3.0.0",
+        "sigstore": "^1.3.0",
+        "ssri": "^10.0.0",
         "tar": "^6.1.11"
       },
       "bin": {
         "pacote": "lib/bin.js"
       },
       "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/pacote/node_modules/minipass": {
+      "version": "5.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/npm/node_modules/parse-conflict-json": {
-      "version": "2.0.2",
+      "version": "3.0.1",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "json-parse-even-better-errors": "^2.3.1",
-        "just-diff": "^5.0.1",
+        "json-parse-even-better-errors": "^3.0.0",
+        "just-diff": "^6.0.0",
         "just-diff-apply": "^5.2.0"
       },
       "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
     "node_modules/npm/node_modules/path-is-absolute": {
@@ -22231,13 +23209,60 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/npm/node_modules/proc-log": {
-      "version": "2.0.1",
+    "node_modules/npm/node_modules/path-key": {
+      "version": "3.1.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/npm/node_modules/path-scurry": {
+      "version": "1.10.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^9.1.1 || ^10.0.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/npm/node_modules/path-scurry/node_modules/lru-cache": {
+      "version": "10.2.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+        "node": "14 || >=16.14"
+      }
+    },
+    "node_modules/npm/node_modules/postcss-selector-parser": {
+      "version": "6.0.15",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssesc": "^3.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/npm/node_modules/proc-log": {
+      "version": "3.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
     "node_modules/npm/node_modules/promise-all-reject-late": {
@@ -22250,7 +23275,7 @@
       }
     },
     "node_modules/npm/node_modules/promise-call-limit": {
-      "version": "1.0.1",
+      "version": "1.0.2",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -22278,12 +23303,15 @@
       }
     },
     "node_modules/npm/node_modules/promzard": {
-      "version": "0.3.0",
+      "version": "1.0.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "read": "1"
+        "read": "^2.0.0"
+      },
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
     "node_modules/npm/node_modules/qrcode-terminal": {
@@ -22295,56 +23323,56 @@
       }
     },
     "node_modules/npm/node_modules/read": {
-      "version": "1.0.7",
+      "version": "2.1.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "mute-stream": "~0.0.4"
+        "mute-stream": "~1.0.0"
       },
       "engines": {
-        "node": ">=0.8"
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
     "node_modules/npm/node_modules/read-cmd-shim": {
-      "version": "3.0.0",
+      "version": "4.0.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
     "node_modules/npm/node_modules/read-package-json": {
-      "version": "5.0.1",
+      "version": "6.0.4",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "glob": "^8.0.1",
-        "json-parse-even-better-errors": "^2.3.1",
-        "normalize-package-data": "^4.0.0",
-        "npm-normalize-package-bin": "^1.0.1"
+        "glob": "^10.2.2",
+        "json-parse-even-better-errors": "^3.0.0",
+        "normalize-package-data": "^5.0.0",
+        "npm-normalize-package-bin": "^3.0.0"
       },
       "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
     "node_modules/npm/node_modules/read-package-json-fast": {
-      "version": "2.0.3",
+      "version": "3.0.2",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "json-parse-even-better-errors": "^2.3.0",
-        "npm-normalize-package-bin": "^1.0.1"
+        "json-parse-even-better-errors": "^3.0.0",
+        "npm-normalize-package-bin": "^3.0.0"
       },
       "engines": {
-        "node": ">=10"
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
     "node_modules/npm/node_modules/readable-stream": {
-      "version": "3.6.0",
+      "version": "3.6.2",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -22355,18 +23383,6 @@
       },
       "engines": {
         "node": ">= 6"
-      }
-    },
-    "node_modules/npm/node_modules/readdir-scoped-modules": {
-      "version": "1.1.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "debuglog": "^1.0.1",
-        "dezalgo": "^1.0.0",
-        "graceful-fs": "^4.1.2",
-        "once": "^1.3.0"
       }
     },
     "node_modules/npm/node_modules/retry": {
@@ -22463,7 +23479,7 @@
       "optional": true
     },
     "node_modules/npm/node_modules/semver": {
-      "version": "7.3.7",
+      "version": "7.6.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -22495,11 +23511,57 @@
       "inBundle": true,
       "license": "ISC"
     },
-    "node_modules/npm/node_modules/signal-exit": {
-      "version": "3.0.7",
+    "node_modules/npm/node_modules/shebang-command": {
+      "version": "2.0.0",
       "dev": true,
       "inBundle": true,
-      "license": "ISC"
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/npm/node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/npm/node_modules/signal-exit": {
+      "version": "4.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/npm/node_modules/sigstore": {
+      "version": "1.9.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@sigstore/bundle": "^1.1.0",
+        "@sigstore/protobuf-specs": "^0.2.0",
+        "@sigstore/sign": "^1.0.0",
+        "@sigstore/tuf": "^1.0.3",
+        "make-fetch-happen": "^11.0.1"
+      },
+      "bin": {
+        "sigstore": "bin/sigstore.js"
+      },
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
     },
     "node_modules/npm/node_modules/smart-buffer": {
       "version": "4.2.0",
@@ -22512,21 +23574,21 @@
       }
     },
     "node_modules/npm/node_modules/socks": {
-      "version": "2.6.2",
+      "version": "2.8.1",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
-        "ip": "^1.1.5",
+        "ip-address": "^9.0.5",
         "smart-buffer": "^4.2.0"
       },
       "engines": {
-        "node": ">= 10.13.0",
+        "node": ">= 10.0.0",
         "npm": ">= 3.0.0"
       }
     },
     "node_modules/npm/node_modules/socks-proxy-agent": {
-      "version": "6.2.0",
+      "version": "7.0.0",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -22540,7 +23602,7 @@
       }
     },
     "node_modules/npm/node_modules/spdx-correct": {
-      "version": "3.1.1",
+      "version": "3.2.0",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
@@ -22550,7 +23612,7 @@
       }
     },
     "node_modules/npm/node_modules/spdx-exceptions": {
-      "version": "2.3.0",
+      "version": "2.5.0",
       "dev": true,
       "inBundle": true,
       "license": "CC-BY-3.0"
@@ -22566,21 +23628,21 @@
       }
     },
     "node_modules/npm/node_modules/spdx-license-ids": {
-      "version": "3.0.11",
+      "version": "3.0.17",
       "dev": true,
       "inBundle": true,
       "license": "CC0-1.0"
     },
     "node_modules/npm/node_modules/ssri": {
-      "version": "9.0.1",
+      "version": "10.0.5",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "minipass": "^3.1.1"
+        "minipass": "^7.0.3"
       },
       "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
     "node_modules/npm/node_modules/string_decoder": {
@@ -22606,6 +23668,21 @@
         "node": ">=8"
       }
     },
+    "node_modules/npm/node_modules/string-width-cjs": {
+      "name": "string-width",
+      "version": "4.2.3",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/npm/node_modules/strip-ansi": {
       "version": "6.0.1",
       "dev": true,
@@ -22618,33 +23695,79 @@
         "node": ">=8"
       }
     },
-    "node_modules/npm/node_modules/supports-color": {
-      "version": "7.2.0",
+    "node_modules/npm/node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
+      "version": "6.0.1",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
-        "has-flag": "^4.0.0"
+        "ansi-regex": "^5.0.1"
       },
       "engines": {
         "node": ">=8"
       }
     },
+    "node_modules/npm/node_modules/supports-color": {
+      "version": "9.4.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
     "node_modules/npm/node_modules/tar": {
-      "version": "6.1.11",
+      "version": "6.2.1",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
         "chownr": "^2.0.0",
         "fs-minipass": "^2.0.0",
-        "minipass": "^3.0.0",
+        "minipass": "^5.0.0",
         "minizlib": "^2.1.1",
         "mkdirp": "^1.0.3",
         "yallist": "^4.0.0"
       },
       "engines": {
-        "node": ">= 10"
+        "node": ">=10"
+      }
+    },
+    "node_modules/npm/node_modules/tar/node_modules/fs-minipass": {
+      "version": "2.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/npm/node_modules/tar/node_modules/fs-minipass/node_modules/minipass": {
+      "version": "3.3.6",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/npm/node_modules/tar/node_modules/minipass": {
+      "version": "5.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/npm/node_modules/text-table": {
@@ -22660,30 +23783,50 @@
       "license": "MIT"
     },
     "node_modules/npm/node_modules/treeverse": {
-      "version": "2.0.0",
+      "version": "3.0.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/tuf-js": {
+      "version": "1.1.7",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "@tufjs/models": "1.0.4",
+        "debug": "^4.3.4",
+        "make-fetch-happen": "^11.1.1"
+      },
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
     "node_modules/npm/node_modules/unique-filename": {
-      "version": "1.1.1",
+      "version": "3.0.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "unique-slug": "^2.0.0"
+        "unique-slug": "^4.0.0"
+      },
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
     "node_modules/npm/node_modules/unique-slug": {
-      "version": "2.0.2",
+      "version": "4.0.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
         "imurmurhash": "^0.1.4"
+      },
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
     "node_modules/npm/node_modules/util-deprecate": {
@@ -22703,7 +23846,7 @@
       }
     },
     "node_modules/npm/node_modules/validate-npm-package-name": {
-      "version": "4.0.0",
+      "version": "5.0.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -22711,11 +23854,11 @@
         "builtins": "^5.0.0"
       },
       "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
     "node_modules/npm/node_modules/walk-up-path": {
-      "version": "1.0.0",
+      "version": "3.0.1",
       "dev": true,
       "inBundle": true,
       "license": "ISC"
@@ -22730,7 +23873,7 @@
       }
     },
     "node_modules/npm/node_modules/which": {
-      "version": "2.0.2",
+      "version": "3.0.1",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -22738,10 +23881,10 @@
         "isexe": "^2.0.0"
       },
       "bin": {
-        "node-which": "bin/node-which"
+        "node-which": "bin/which.js"
       },
       "engines": {
-        "node": ">= 8"
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
     "node_modules/npm/node_modules/wide-align": {
@@ -22753,6 +23896,103 @@
         "string-width": "^1.0.2 || 2 || 3 || 4"
       }
     },
+    "node_modules/npm/node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/npm/node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
+      "version": "7.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/npm/node_modules/wrap-ansi/node_modules/ansi-regex": {
+      "version": "6.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/npm/node_modules/wrap-ansi/node_modules/ansi-styles": {
+      "version": "6.2.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/npm/node_modules/wrap-ansi/node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/wrap-ansi/node_modules/string-width": {
+      "version": "5.1.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/npm/node_modules/wrap-ansi/node_modules/strip-ansi": {
+      "version": "7.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
     "node_modules/npm/node_modules/wrappy": {
       "version": "1.0.2",
       "dev": true,
@@ -22760,16 +24000,16 @@
       "license": "ISC"
     },
     "node_modules/npm/node_modules/write-file-atomic": {
-      "version": "4.0.1",
+      "version": "5.0.1",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
         "imurmurhash": "^0.1.4",
-        "signal-exit": "^3.0.7"
+        "signal-exit": "^4.0.1"
       },
       "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16"
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
     "node_modules/npm/node_modules/yallist": {
@@ -23641,9 +24881,9 @@
       }
     },
     "node_modules/picocolors": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
-      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
       "dev": true
     },
     "node_modules/picomatch": {
@@ -25135,6 +26375,12 @@
         "node": ">= 6"
       }
     },
+    "node_modules/proto-list": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
+      "integrity": "sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA==",
+      "dev": true
+    },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -25747,15 +26993,15 @@
       }
     },
     "node_modules/registry-auth-token": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-4.2.1.tgz",
-      "integrity": "sha512-6gkSb4U6aWJB4SF2ZvLb76yCBjcvufXBqvvEx1HbmKPkutswjW1xNVRY0+daljIYRbogN7O0etYSlbiaEQyMyw==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-5.1.1.tgz",
+      "integrity": "sha512-P7B4+jq8DeD2nMsAcdfaqHbssgHtZ7Z5+++a5ask90fvmJ8p5je4mOa+wzu+DB4vQ5tdJV/xywY+UnVFeQLV5Q==",
       "dev": true,
       "dependencies": {
-        "rc": "^1.2.8"
+        "@pnpm/npm-conf": "^3.0.2"
       },
       "engines": {
-        "node": ">=6.0.0"
+        "node": ">=14"
       }
     },
     "node_modules/regjsgen": {
@@ -26281,6 +27527,2674 @@
       },
       "engines": {
         "node": ">=16 || ^14.17"
+      }
+    },
+    "node_modules/semantic-release/node_modules/@semantic-release/npm": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/@semantic-release/npm/-/npm-9.0.2.tgz",
+      "integrity": "sha512-zgsynF6McdzxPnFet+a4iO9HpAlARXOM5adz7VGVCvj0ne8wtL2ZOQoDV2wZPDmdEotDIbVeJjafhelZjs9j6g==",
+      "dev": true,
+      "dependencies": {
+        "@semantic-release/error": "^3.0.0",
+        "aggregate-error": "^3.0.0",
+        "execa": "^5.0.0",
+        "fs-extra": "^11.0.0",
+        "lodash": "^4.17.15",
+        "nerf-dart": "^1.0.0",
+        "normalize-url": "^6.0.0",
+        "npm": "^8.3.0",
+        "rc": "^1.2.8",
+        "read-pkg": "^5.0.0",
+        "registry-auth-token": "^5.0.0",
+        "semver": "^7.1.2",
+        "tempy": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=16 || ^14.17"
+      },
+      "peerDependencies": {
+        "semantic-release": ">=19.0.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/crypto-random-string": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-2.0.0.tgz",
+      "integrity": "sha512-v1plID3y9r/lPhviJ1wrXpLeyUIGAZ2SHNYTEapm7/8A9nLPoyvVp3RK/EPFqn5kEznyWgYZNsRtYYIWbuG8KA==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/semantic-release/node_modules/fs-extra": {
+      "version": "11.3.6",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.6.tgz",
+      "integrity": "sha512-w8ZNZr2mKIc7qeNaQ9AVPT1+iFaI+Avd4xudVOvdDJ8VytREi1Ft5Ih7hd9jjehod8vAM5GMsfQ/TpPf4EyoEA==",
+      "dev": true,
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm": {
+      "version": "8.19.4",
+      "resolved": "https://registry.npmjs.org/npm/-/npm-8.19.4.tgz",
+      "integrity": "sha512-3HANl8i9DKnUA89P4KEgVNN28EjSeDCmvEqbzOAuxCFDzdBZzjUl99zgnGpOUumvW5lvJo2HKcjrsc+tfyv1Hw==",
+      "bundleDependencies": [
+        "@isaacs/string-locale-compare",
+        "@npmcli/arborist",
+        "@npmcli/ci-detect",
+        "@npmcli/config",
+        "@npmcli/fs",
+        "@npmcli/map-workspaces",
+        "@npmcli/package-json",
+        "@npmcli/run-script",
+        "abbrev",
+        "archy",
+        "cacache",
+        "chalk",
+        "chownr",
+        "cli-columns",
+        "cli-table3",
+        "columnify",
+        "fastest-levenshtein",
+        "fs-minipass",
+        "glob",
+        "graceful-fs",
+        "hosted-git-info",
+        "ini",
+        "init-package-json",
+        "is-cidr",
+        "json-parse-even-better-errors",
+        "libnpmaccess",
+        "libnpmdiff",
+        "libnpmexec",
+        "libnpmfund",
+        "libnpmhook",
+        "libnpmorg",
+        "libnpmpack",
+        "libnpmpublish",
+        "libnpmsearch",
+        "libnpmteam",
+        "libnpmversion",
+        "make-fetch-happen",
+        "minimatch",
+        "minipass",
+        "minipass-pipeline",
+        "mkdirp",
+        "mkdirp-infer-owner",
+        "ms",
+        "node-gyp",
+        "nopt",
+        "npm-audit-report",
+        "npm-install-checks",
+        "npm-package-arg",
+        "npm-pick-manifest",
+        "npm-profile",
+        "npm-registry-fetch",
+        "npm-user-validate",
+        "npmlog",
+        "opener",
+        "p-map",
+        "pacote",
+        "parse-conflict-json",
+        "proc-log",
+        "qrcode-terminal",
+        "read",
+        "read-package-json",
+        "read-package-json-fast",
+        "readdir-scoped-modules",
+        "rimraf",
+        "semver",
+        "ssri",
+        "tar",
+        "text-table",
+        "tiny-relative-date",
+        "treeverse",
+        "validate-npm-package-name",
+        "which",
+        "write-file-atomic"
+      ],
+      "dev": true,
+      "dependencies": {
+        "@isaacs/string-locale-compare": "^1.1.0",
+        "@npmcli/arborist": "^5.6.3",
+        "@npmcli/ci-detect": "^2.0.0",
+        "@npmcli/config": "^4.2.1",
+        "@npmcli/fs": "^2.1.0",
+        "@npmcli/map-workspaces": "^2.0.3",
+        "@npmcli/package-json": "^2.0.0",
+        "@npmcli/run-script": "^4.2.1",
+        "abbrev": "~1.1.1",
+        "archy": "~1.0.0",
+        "cacache": "^16.1.3",
+        "chalk": "^4.1.2",
+        "chownr": "^2.0.0",
+        "cli-columns": "^4.0.0",
+        "cli-table3": "^0.6.2",
+        "columnify": "^1.6.0",
+        "fastest-levenshtein": "^1.0.12",
+        "fs-minipass": "^2.1.0",
+        "glob": "^8.0.1",
+        "graceful-fs": "^4.2.10",
+        "hosted-git-info": "^5.2.1",
+        "ini": "^3.0.1",
+        "init-package-json": "^3.0.2",
+        "is-cidr": "^4.0.2",
+        "json-parse-even-better-errors": "^2.3.1",
+        "libnpmaccess": "^6.0.4",
+        "libnpmdiff": "^4.0.5",
+        "libnpmexec": "^4.0.14",
+        "libnpmfund": "^3.0.5",
+        "libnpmhook": "^8.0.4",
+        "libnpmorg": "^4.0.4",
+        "libnpmpack": "^4.1.3",
+        "libnpmpublish": "^6.0.5",
+        "libnpmsearch": "^5.0.4",
+        "libnpmteam": "^4.0.4",
+        "libnpmversion": "^3.0.7",
+        "make-fetch-happen": "^10.2.0",
+        "minimatch": "^5.1.0",
+        "minipass": "^3.1.6",
+        "minipass-pipeline": "^1.2.4",
+        "mkdirp": "^1.0.4",
+        "mkdirp-infer-owner": "^2.0.0",
+        "ms": "^2.1.2",
+        "node-gyp": "^9.1.0",
+        "nopt": "^6.0.0",
+        "npm-audit-report": "^3.0.0",
+        "npm-install-checks": "^5.0.0",
+        "npm-package-arg": "^9.1.0",
+        "npm-pick-manifest": "^7.0.2",
+        "npm-profile": "^6.2.0",
+        "npm-registry-fetch": "^13.3.1",
+        "npm-user-validate": "^1.0.1",
+        "npmlog": "^6.0.2",
+        "opener": "^1.5.2",
+        "p-map": "^4.0.0",
+        "pacote": "^13.6.2",
+        "parse-conflict-json": "^2.0.2",
+        "proc-log": "^2.0.1",
+        "qrcode-terminal": "^0.12.0",
+        "read": "~1.0.7",
+        "read-package-json": "^5.0.2",
+        "read-package-json-fast": "^2.0.3",
+        "readdir-scoped-modules": "^1.1.0",
+        "rimraf": "^3.0.2",
+        "semver": "^7.3.7",
+        "ssri": "^9.0.1",
+        "tar": "^6.1.11",
+        "text-table": "~0.2.0",
+        "tiny-relative-date": "^1.3.0",
+        "treeverse": "^2.0.0",
+        "validate-npm-package-name": "^4.0.0",
+        "which": "^2.0.2",
+        "write-file-atomic": "^4.0.1"
+      },
+      "bin": {
+        "npm": "bin/npm-cli.js",
+        "npx": "bin/npx-cli.js"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/@colors/colors": {
+      "version": "1.5.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.1.90"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/@gar/promisify": {
+      "version": "1.1.3",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/@isaacs/string-locale-compare": {
+      "version": "1.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/@npmcli/arborist": {
+      "version": "5.6.3",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "@isaacs/string-locale-compare": "^1.1.0",
+        "@npmcli/installed-package-contents": "^1.0.7",
+        "@npmcli/map-workspaces": "^2.0.3",
+        "@npmcli/metavuln-calculator": "^3.0.1",
+        "@npmcli/move-file": "^2.0.0",
+        "@npmcli/name-from-folder": "^1.0.1",
+        "@npmcli/node-gyp": "^2.0.0",
+        "@npmcli/package-json": "^2.0.0",
+        "@npmcli/query": "^1.2.0",
+        "@npmcli/run-script": "^4.1.3",
+        "bin-links": "^3.0.3",
+        "cacache": "^16.1.3",
+        "common-ancestor-path": "^1.0.1",
+        "hosted-git-info": "^5.2.1",
+        "json-parse-even-better-errors": "^2.3.1",
+        "json-stringify-nice": "^1.1.4",
+        "minimatch": "^5.1.0",
+        "mkdirp": "^1.0.4",
+        "mkdirp-infer-owner": "^2.0.0",
+        "nopt": "^6.0.0",
+        "npm-install-checks": "^5.0.0",
+        "npm-package-arg": "^9.0.0",
+        "npm-pick-manifest": "^7.0.2",
+        "npm-registry-fetch": "^13.0.0",
+        "npmlog": "^6.0.2",
+        "pacote": "^13.6.1",
+        "parse-conflict-json": "^2.0.1",
+        "proc-log": "^2.0.0",
+        "promise-all-reject-late": "^1.0.0",
+        "promise-call-limit": "^1.0.1",
+        "read-package-json-fast": "^2.0.2",
+        "readdir-scoped-modules": "^1.1.0",
+        "rimraf": "^3.0.2",
+        "semver": "^7.3.7",
+        "ssri": "^9.0.0",
+        "treeverse": "^2.0.0",
+        "walk-up-path": "^1.0.0"
+      },
+      "bin": {
+        "arborist": "bin/index.js"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/@npmcli/ci-detect": {
+      "version": "2.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/@npmcli/config": {
+      "version": "4.2.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "@npmcli/map-workspaces": "^2.0.2",
+        "ini": "^3.0.0",
+        "mkdirp-infer-owner": "^2.0.0",
+        "nopt": "^6.0.0",
+        "proc-log": "^2.0.0",
+        "read-package-json-fast": "^2.0.3",
+        "semver": "^7.3.5",
+        "walk-up-path": "^1.0.0"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/@npmcli/disparity-colors": {
+      "version": "2.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "ansi-styles": "^4.3.0"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/@npmcli/fs": {
+      "version": "2.1.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "@gar/promisify": "^1.1.3",
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/@npmcli/git": {
+      "version": "3.0.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "@npmcli/promise-spawn": "^3.0.0",
+        "lru-cache": "^7.4.4",
+        "mkdirp": "^1.0.4",
+        "npm-pick-manifest": "^7.0.0",
+        "proc-log": "^2.0.0",
+        "promise-inflight": "^1.0.1",
+        "promise-retry": "^2.0.1",
+        "semver": "^7.3.5",
+        "which": "^2.0.2"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/@npmcli/installed-package-contents": {
+      "version": "1.0.7",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "npm-bundled": "^1.1.1",
+        "npm-normalize-package-bin": "^1.0.1"
+      },
+      "bin": {
+        "installed-package-contents": "index.js"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/@npmcli/installed-package-contents/node_modules/npm-bundled": {
+      "version": "1.1.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "npm-normalize-package-bin": "^1.0.1"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/@npmcli/map-workspaces": {
+      "version": "2.0.4",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "@npmcli/name-from-folder": "^1.0.1",
+        "glob": "^8.0.1",
+        "minimatch": "^5.0.1",
+        "read-package-json-fast": "^2.0.3"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/@npmcli/metavuln-calculator": {
+      "version": "3.1.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "cacache": "^16.0.0",
+        "json-parse-even-better-errors": "^2.3.1",
+        "pacote": "^13.0.3",
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/@npmcli/move-file": {
+      "version": "2.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "mkdirp": "^1.0.4",
+        "rimraf": "^3.0.2"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/@npmcli/name-from-folder": {
+      "version": "1.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/@npmcli/node-gyp": {
+      "version": "2.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/@npmcli/package-json": {
+      "version": "2.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "json-parse-even-better-errors": "^2.3.1"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/@npmcli/promise-spawn": {
+      "version": "3.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "infer-owner": "^1.0.4"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/@npmcli/query": {
+      "version": "1.2.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "npm-package-arg": "^9.1.0",
+        "postcss-selector-parser": "^6.0.10",
+        "semver": "^7.3.7"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/@npmcli/run-script": {
+      "version": "4.2.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "@npmcli/node-gyp": "^2.0.0",
+        "@npmcli/promise-spawn": "^3.0.0",
+        "node-gyp": "^9.0.0",
+        "read-package-json-fast": "^2.0.3",
+        "which": "^2.0.2"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/@tootallnate/once": {
+      "version": "2.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/abbrev": {
+      "version": "1.1.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/agent-base": {
+      "version": "6.0.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/agentkeepalive": {
+      "version": "4.2.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.1.0",
+        "depd": "^1.1.2",
+        "humanize-ms": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/aggregate-error": {
+      "version": "3.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "clean-stack": "^2.0.0",
+        "indent-string": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/aproba": {
+      "version": "2.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/archy": {
+      "version": "1.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/are-we-there-yet": {
+      "version": "3.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "delegates": "^1.0.0",
+        "readable-stream": "^3.6.0"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/asap": {
+      "version": "2.0.6",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/bin-links": {
+      "version": "3.0.3",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "cmd-shim": "^5.0.0",
+        "mkdirp-infer-owner": "^2.0.0",
+        "npm-normalize-package-bin": "^2.0.0",
+        "read-cmd-shim": "^3.0.0",
+        "rimraf": "^3.0.0",
+        "write-file-atomic": "^4.0.0"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/bin-links/node_modules/npm-normalize-package-bin": {
+      "version": "2.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/binary-extensions": {
+      "version": "2.2.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/builtins": {
+      "version": "5.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.0.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/cacache": {
+      "version": "16.1.3",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "@npmcli/fs": "^2.1.0",
+        "@npmcli/move-file": "^2.0.0",
+        "chownr": "^2.0.0",
+        "fs-minipass": "^2.1.0",
+        "glob": "^8.0.1",
+        "infer-owner": "^1.0.4",
+        "lru-cache": "^7.7.1",
+        "minipass": "^3.1.6",
+        "minipass-collect": "^1.0.2",
+        "minipass-flush": "^1.0.5",
+        "minipass-pipeline": "^1.2.4",
+        "mkdirp": "^1.0.4",
+        "p-map": "^4.0.0",
+        "promise-inflight": "^1.0.1",
+        "rimraf": "^3.0.2",
+        "ssri": "^9.0.0",
+        "tar": "^6.1.11",
+        "unique-filename": "^2.0.0"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/chalk": {
+      "version": "4.1.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/chownr": {
+      "version": "2.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/cidr-regex": {
+      "version": "3.1.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "ip-regex": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/clean-stack": {
+      "version": "2.2.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/cli-columns": {
+      "version": "4.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "string-width": "^4.2.3",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/cli-table3": {
+      "version": "0.6.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "string-width": "^4.2.0"
+      },
+      "engines": {
+        "node": "10.* || >= 12.*"
+      },
+      "optionalDependencies": {
+        "@colors/colors": "1.5.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/clone": {
+      "version": "1.0.4",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/cmd-shim": {
+      "version": "5.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "mkdirp-infer-owner": "^2.0.0"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/color-convert": {
+      "version": "2.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/color-name": {
+      "version": "1.1.4",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/color-support": {
+      "version": "1.1.3",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "bin": {
+        "color-support": "bin.js"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/columnify": {
+      "version": "1.6.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "strip-ansi": "^6.0.1",
+        "wcwidth": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/common-ancestor-path": {
+      "version": "1.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/concat-map": {
+      "version": "0.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/console-control-strings": {
+      "version": "1.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/cssesc": {
+      "version": "3.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "bin": {
+        "cssesc": "bin/cssesc"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/debug": {
+      "version": "4.3.4",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/debug/node_modules/ms": {
+      "version": "2.1.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/debuglog": {
+      "version": "1.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/defaults": {
+      "version": "1.0.3",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "clone": "^1.0.2"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/delegates": {
+      "version": "1.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/depd": {
+      "version": "1.1.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/dezalgo": {
+      "version": "1.0.4",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "asap": "^2.0.0",
+        "wrappy": "1"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/diff": {
+      "version": "5.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/encoding": {
+      "version": "0.1.13",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "iconv-lite": "^0.6.2"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/env-paths": {
+      "version": "2.2.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/err-code": {
+      "version": "2.0.3",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/fastest-levenshtein": {
+      "version": "1.0.12",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/fs-minipass": {
+      "version": "2.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/function-bind": {
+      "version": "1.1.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/gauge": {
+      "version": "4.0.4",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "aproba": "^1.0.3 || ^2.0.0",
+        "color-support": "^1.1.3",
+        "console-control-strings": "^1.1.0",
+        "has-unicode": "^2.0.1",
+        "signal-exit": "^3.0.7",
+        "string-width": "^4.2.3",
+        "strip-ansi": "^6.0.1",
+        "wide-align": "^1.1.5"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/glob": {
+      "version": "8.0.3",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^5.0.1",
+        "once": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/graceful-fs": {
+      "version": "4.2.10",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/has": {
+      "version": "1.0.3",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/has-flag": {
+      "version": "4.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/has-unicode": {
+      "version": "2.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/hosted-git-info": {
+      "version": "5.2.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "lru-cache": "^7.5.1"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/http-cache-semantics": {
+      "version": "4.1.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/http-proxy-agent": {
+      "version": "5.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "@tootallnate/once": "2",
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/humanize-ms": {
+      "version": "1.2.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.0.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/ignore-walk": {
+      "version": "5.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "minimatch": "^5.0.1"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.19"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/indent-string": {
+      "version": "4.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/infer-owner": {
+      "version": "1.0.4",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/inflight": {
+      "version": "1.0.6",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/inherits": {
+      "version": "2.0.4",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/ini": {
+      "version": "3.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/init-package-json": {
+      "version": "3.0.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "npm-package-arg": "^9.0.1",
+        "promzard": "^0.3.0",
+        "read": "^1.0.7",
+        "read-package-json": "^5.0.0",
+        "semver": "^7.3.5",
+        "validate-npm-package-license": "^3.0.4",
+        "validate-npm-package-name": "^4.0.0"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/ip": {
+      "version": "2.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/ip-regex": {
+      "version": "4.3.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/is-cidr": {
+      "version": "4.0.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "cidr-regex": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/is-core-module": {
+      "version": "2.10.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "has": "^1.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/is-lambda": {
+      "version": "1.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/isexe": {
+      "version": "2.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/json-parse-even-better-errors": {
+      "version": "2.3.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/json-stringify-nice": {
+      "version": "1.1.4",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/jsonparse": {
+      "version": "1.3.1",
+      "dev": true,
+      "engines": [
+        "node >= 0.2.0"
+      ],
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/just-diff": {
+      "version": "5.1.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/just-diff-apply": {
+      "version": "5.4.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/libnpmaccess": {
+      "version": "6.0.4",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "aproba": "^2.0.0",
+        "minipass": "^3.1.1",
+        "npm-package-arg": "^9.0.1",
+        "npm-registry-fetch": "^13.0.0"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/libnpmdiff": {
+      "version": "4.0.5",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "@npmcli/disparity-colors": "^2.0.0",
+        "@npmcli/installed-package-contents": "^1.0.7",
+        "binary-extensions": "^2.2.0",
+        "diff": "^5.1.0",
+        "minimatch": "^5.0.1",
+        "npm-package-arg": "^9.0.1",
+        "pacote": "^13.6.1",
+        "tar": "^6.1.0"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/libnpmexec": {
+      "version": "4.0.14",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "@npmcli/arborist": "^5.6.3",
+        "@npmcli/ci-detect": "^2.0.0",
+        "@npmcli/fs": "^2.1.1",
+        "@npmcli/run-script": "^4.2.0",
+        "chalk": "^4.1.0",
+        "mkdirp-infer-owner": "^2.0.0",
+        "npm-package-arg": "^9.0.1",
+        "npmlog": "^6.0.2",
+        "pacote": "^13.6.1",
+        "proc-log": "^2.0.0",
+        "read": "^1.0.7",
+        "read-package-json-fast": "^2.0.2",
+        "semver": "^7.3.7",
+        "walk-up-path": "^1.0.0"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/libnpmfund": {
+      "version": "3.0.5",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "@npmcli/arborist": "^5.6.3"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/libnpmhook": {
+      "version": "8.0.4",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "aproba": "^2.0.0",
+        "npm-registry-fetch": "^13.0.0"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/libnpmorg": {
+      "version": "4.0.4",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "aproba": "^2.0.0",
+        "npm-registry-fetch": "^13.0.0"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/libnpmpack": {
+      "version": "4.1.3",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "@npmcli/run-script": "^4.1.3",
+        "npm-package-arg": "^9.0.1",
+        "pacote": "^13.6.1"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/libnpmpublish": {
+      "version": "6.0.5",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "normalize-package-data": "^4.0.0",
+        "npm-package-arg": "^9.0.1",
+        "npm-registry-fetch": "^13.0.0",
+        "semver": "^7.3.7",
+        "ssri": "^9.0.0"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/libnpmsearch": {
+      "version": "5.0.4",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "npm-registry-fetch": "^13.0.0"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/libnpmteam": {
+      "version": "4.0.4",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "aproba": "^2.0.0",
+        "npm-registry-fetch": "^13.0.0"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/libnpmversion": {
+      "version": "3.0.7",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "@npmcli/git": "^3.0.0",
+        "@npmcli/run-script": "^4.1.3",
+        "json-parse-even-better-errors": "^2.3.1",
+        "proc-log": "^2.0.0",
+        "semver": "^7.3.7"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/lru-cache": {
+      "version": "7.13.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/make-fetch-happen": {
+      "version": "10.2.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "agentkeepalive": "^4.2.1",
+        "cacache": "^16.1.0",
+        "http-cache-semantics": "^4.1.0",
+        "http-proxy-agent": "^5.0.0",
+        "https-proxy-agent": "^5.0.0",
+        "is-lambda": "^1.0.1",
+        "lru-cache": "^7.7.1",
+        "minipass": "^3.1.6",
+        "minipass-collect": "^1.0.2",
+        "minipass-fetch": "^2.0.3",
+        "minipass-flush": "^1.0.5",
+        "minipass-pipeline": "^1.2.4",
+        "negotiator": "^0.6.3",
+        "promise-retry": "^2.0.1",
+        "socks-proxy-agent": "^7.0.0",
+        "ssri": "^9.0.0"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/minimatch": {
+      "version": "5.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/minipass": {
+      "version": "3.3.4",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/minipass-collect": {
+      "version": "1.0.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/minipass-fetch": {
+      "version": "2.1.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "minipass": "^3.1.6",
+        "minipass-sized": "^1.0.3",
+        "minizlib": "^2.1.2"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      },
+      "optionalDependencies": {
+        "encoding": "^0.1.13"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/minipass-flush": {
+      "version": "1.0.5",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/minipass-json-stream": {
+      "version": "1.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "jsonparse": "^1.3.1",
+        "minipass": "^3.0.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/minipass-pipeline": {
+      "version": "1.2.4",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/minipass-sized": {
+      "version": "1.0.3",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/minizlib": {
+      "version": "2.1.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "minipass": "^3.0.0",
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/mkdirp": {
+      "version": "1.0.4",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/mkdirp-infer-owner": {
+      "version": "2.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "chownr": "^2.0.0",
+        "infer-owner": "^1.0.4",
+        "mkdirp": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/ms": {
+      "version": "2.1.3",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/mute-stream": {
+      "version": "0.0.8",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/negotiator": {
+      "version": "0.6.3",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/node-gyp": {
+      "version": "9.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "env-paths": "^2.2.0",
+        "glob": "^7.1.4",
+        "graceful-fs": "^4.2.6",
+        "make-fetch-happen": "^10.0.3",
+        "nopt": "^5.0.0",
+        "npmlog": "^6.0.0",
+        "rimraf": "^3.0.2",
+        "semver": "^7.3.5",
+        "tar": "^6.1.2",
+        "which": "^2.0.2"
+      },
+      "bin": {
+        "node-gyp": "bin/node-gyp.js"
+      },
+      "engines": {
+        "node": "^12.22 || ^14.13 || >=16"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/node-gyp/node_modules/brace-expansion": {
+      "version": "1.1.11",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/node-gyp/node_modules/glob": {
+      "version": "7.2.3",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/node-gyp/node_modules/minimatch": {
+      "version": "3.1.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/node-gyp/node_modules/nopt": {
+      "version": "5.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "abbrev": "1"
+      },
+      "bin": {
+        "nopt": "bin/nopt.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/nopt": {
+      "version": "6.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "abbrev": "^1.0.0"
+      },
+      "bin": {
+        "nopt": "bin/nopt.js"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/normalize-package-data": {
+      "version": "4.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "hosted-git-info": "^5.0.0",
+        "is-core-module": "^2.8.1",
+        "semver": "^7.3.5",
+        "validate-npm-package-license": "^3.0.4"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/npm-audit-report": {
+      "version": "3.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "chalk": "^4.0.0"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/npm-bundled": {
+      "version": "2.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "npm-normalize-package-bin": "^2.0.0"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/npm-bundled/node_modules/npm-normalize-package-bin": {
+      "version": "2.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/npm-install-checks": {
+      "version": "5.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "semver": "^7.1.1"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/npm-normalize-package-bin": {
+      "version": "1.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/npm-package-arg": {
+      "version": "9.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "hosted-git-info": "^5.0.0",
+        "proc-log": "^2.0.1",
+        "semver": "^7.3.5",
+        "validate-npm-package-name": "^4.0.0"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/npm-packlist": {
+      "version": "5.1.3",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "glob": "^8.0.1",
+        "ignore-walk": "^5.0.1",
+        "npm-bundled": "^2.0.0",
+        "npm-normalize-package-bin": "^2.0.0"
+      },
+      "bin": {
+        "npm-packlist": "bin/index.js"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/npm-packlist/node_modules/npm-normalize-package-bin": {
+      "version": "2.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/npm-pick-manifest": {
+      "version": "7.0.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "npm-install-checks": "^5.0.0",
+        "npm-normalize-package-bin": "^2.0.0",
+        "npm-package-arg": "^9.0.0",
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/npm-pick-manifest/node_modules/npm-normalize-package-bin": {
+      "version": "2.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/npm-profile": {
+      "version": "6.2.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "npm-registry-fetch": "^13.0.1",
+        "proc-log": "^2.0.0"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/npm-registry-fetch": {
+      "version": "13.3.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "make-fetch-happen": "^10.0.6",
+        "minipass": "^3.1.6",
+        "minipass-fetch": "^2.0.3",
+        "minipass-json-stream": "^1.0.1",
+        "minizlib": "^2.1.2",
+        "npm-package-arg": "^9.0.1",
+        "proc-log": "^2.0.0"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/npm-user-validate": {
+      "version": "1.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/npmlog": {
+      "version": "6.0.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "are-we-there-yet": "^3.0.0",
+        "console-control-strings": "^1.1.0",
+        "gauge": "^4.0.3",
+        "set-blocking": "^2.0.0"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/once": {
+      "version": "1.4.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/opener": {
+      "version": "1.5.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "(WTFPL OR MIT)",
+      "bin": {
+        "opener": "bin/opener-bin.js"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/p-map": {
+      "version": "4.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "aggregate-error": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/pacote": {
+      "version": "13.6.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "@npmcli/git": "^3.0.0",
+        "@npmcli/installed-package-contents": "^1.0.7",
+        "@npmcli/promise-spawn": "^3.0.0",
+        "@npmcli/run-script": "^4.1.0",
+        "cacache": "^16.0.0",
+        "chownr": "^2.0.0",
+        "fs-minipass": "^2.1.0",
+        "infer-owner": "^1.0.4",
+        "minipass": "^3.1.6",
+        "mkdirp": "^1.0.4",
+        "npm-package-arg": "^9.0.0",
+        "npm-packlist": "^5.1.0",
+        "npm-pick-manifest": "^7.0.0",
+        "npm-registry-fetch": "^13.0.1",
+        "proc-log": "^2.0.0",
+        "promise-retry": "^2.0.1",
+        "read-package-json": "^5.0.0",
+        "read-package-json-fast": "^2.0.3",
+        "rimraf": "^3.0.2",
+        "ssri": "^9.0.0",
+        "tar": "^6.1.11"
+      },
+      "bin": {
+        "pacote": "lib/bin.js"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/parse-conflict-json": {
+      "version": "2.0.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "json-parse-even-better-errors": "^2.3.1",
+        "just-diff": "^5.0.1",
+        "just-diff-apply": "^5.2.0"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/postcss-selector-parser": {
+      "version": "6.0.10",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssesc": "^3.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/proc-log": {
+      "version": "2.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/promise-all-reject-late": {
+      "version": "1.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/promise-call-limit": {
+      "version": "1.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/promise-inflight": {
+      "version": "1.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/promise-retry": {
+      "version": "2.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "err-code": "^2.0.2",
+        "retry": "^0.12.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/promzard": {
+      "version": "0.3.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "read": "1"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/qrcode-terminal": {
+      "version": "0.12.0",
+      "dev": true,
+      "inBundle": true,
+      "bin": {
+        "qrcode-terminal": "bin/qrcode-terminal.js"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/read": {
+      "version": "1.0.7",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "mute-stream": "~0.0.4"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/read-cmd-shim": {
+      "version": "3.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/read-package-json": {
+      "version": "5.0.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "glob": "^8.0.1",
+        "json-parse-even-better-errors": "^2.3.1",
+        "normalize-package-data": "^4.0.0",
+        "npm-normalize-package-bin": "^2.0.0"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/read-package-json-fast": {
+      "version": "2.0.3",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "json-parse-even-better-errors": "^2.3.0",
+        "npm-normalize-package-bin": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/read-package-json/node_modules/npm-normalize-package-bin": {
+      "version": "2.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/readable-stream": {
+      "version": "3.6.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/readdir-scoped-modules": {
+      "version": "1.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "debuglog": "^1.0.1",
+        "dezalgo": "^1.0.0",
+        "graceful-fs": "^4.1.2",
+        "once": "^1.3.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/retry": {
+      "version": "0.12.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/rimraf": {
+      "version": "3.0.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/rimraf/node_modules/brace-expansion": {
+      "version": "1.1.11",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/rimraf/node_modules/glob": {
+      "version": "7.2.3",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/rimraf/node_modules/minimatch": {
+      "version": "3.1.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/semver": {
+      "version": "7.3.7",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/semver/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/set-blocking": {
+      "version": "2.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/signal-exit": {
+      "version": "3.0.7",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/smart-buffer": {
+      "version": "4.2.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/socks": {
+      "version": "2.7.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "ip": "^2.0.0",
+        "smart-buffer": "^4.2.0"
+      },
+      "engines": {
+        "node": ">= 10.13.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/socks-proxy-agent": {
+      "version": "7.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^6.0.2",
+        "debug": "^4.3.3",
+        "socks": "^2.6.2"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/spdx-correct": {
+      "version": "3.1.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "spdx-expression-parse": "^3.0.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/spdx-exceptions": {
+      "version": "2.3.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "CC-BY-3.0"
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/spdx-expression-parse": {
+      "version": "3.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "spdx-exceptions": "^2.1.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/spdx-license-ids": {
+      "version": "3.0.11",
+      "dev": true,
+      "inBundle": true,
+      "license": "CC0-1.0"
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/ssri": {
+      "version": "9.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^3.1.1"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/string_decoder": {
+      "version": "1.3.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/string-width": {
+      "version": "4.2.3",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/supports-color": {
+      "version": "7.2.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/tar": {
+      "version": "6.1.11",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "chownr": "^2.0.0",
+        "fs-minipass": "^2.0.0",
+        "minipass": "^3.0.0",
+        "minizlib": "^2.1.1",
+        "mkdirp": "^1.0.3",
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/text-table": {
+      "version": "0.2.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/tiny-relative-date": {
+      "version": "1.3.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/treeverse": {
+      "version": "2.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/unique-filename": {
+      "version": "2.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "unique-slug": "^3.0.0"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/unique-slug": {
+      "version": "3.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "imurmurhash": "^0.1.4"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/validate-npm-package-license": {
+      "version": "3.0.4",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "spdx-correct": "^3.0.0",
+        "spdx-expression-parse": "^3.0.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/validate-npm-package-name": {
+      "version": "4.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "builtins": "^5.0.0"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/walk-up-path": {
+      "version": "1.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/wcwidth": {
+      "version": "1.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "defaults": "^1.0.3"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/which": {
+      "version": "2.0.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/wide-align": {
+      "version": "1.1.5",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^1.0.2 || 2 || 3 || 4"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/wrappy": {
+      "version": "1.0.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/write-file-atomic": {
+      "version": "4.0.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "imurmurhash": "^0.1.4",
+        "signal-exit": "^3.0.7"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/yallist": {
+      "version": "4.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/semantic-release/node_modules/temp-dir": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/temp-dir/-/temp-dir-2.0.0.tgz",
+      "integrity": "sha512-aoBAniQmmwtcKp/7BzsH8Cxzv8OL736p7v1ihGb5e9DJ9kTwGWHrQrVB5+lfVDzfGrdRzXch+ig7LHaY1JTOrg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/semantic-release/node_modules/tempy": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/tempy/-/tempy-1.0.1.tgz",
+      "integrity": "sha512-biM9brNqxSc04Ee71hzFbryD11nX7VPhQQY32AdDmjFvodsRFz/3ufeoTZ6uYkRFfGo188tENcASNs3vTdsM0w==",
+      "dev": true,
+      "dependencies": {
+        "del": "^6.0.0",
+        "is-stream": "^2.0.0",
+        "temp-dir": "^2.0.0",
+        "type-fest": "^0.16.0",
+        "unique-string": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/semantic-release/node_modules/type-fest": {
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.16.0.tgz",
+      "integrity": "sha512-eaBzG6MxNzEn9kiwvtre90cXaNLkmadMWa1zQMs3XORCXNbsH/OewwbxC5ia9dCxIxnTAsSxXJaa/p5y8DlvJg==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/semantic-release/node_modules/unique-string": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-2.0.0.tgz",
+      "integrity": "sha512-uNaeirEPvpZWSgzwsPGtU2zVSTrn/8L5q/IexZmH0eH6SA73CmAA5U4GwORTxQAZs95TAXLNqeLoPPNO5gZfWg==",
+      "dev": true,
+      "dependencies": {
+        "crypto-random-string": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/semantic-release/node_modules/yargs": {
@@ -27432,40 +31346,51 @@
       }
     },
     "node_modules/temp-dir": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/temp-dir/-/temp-dir-2.0.0.tgz",
-      "integrity": "sha512-aoBAniQmmwtcKp/7BzsH8Cxzv8OL736p7v1ihGb5e9DJ9kTwGWHrQrVB5+lfVDzfGrdRzXch+ig7LHaY1JTOrg==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/temp-dir/-/temp-dir-3.0.0.tgz",
+      "integrity": "sha512-nHc6S/bwIilKHNRgK/3jlhDoIHcp45YgyiwcAk46Tr0LfEqGBVpmiAyuiuxeVE44m3mXnEeVhaipLOEWmH+Njw==",
       "dev": true,
       "engines": {
-        "node": ">=8"
+        "node": ">=14.16"
       }
     },
     "node_modules/tempy": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/tempy/-/tempy-1.0.1.tgz",
-      "integrity": "sha512-biM9brNqxSc04Ee71hzFbryD11nX7VPhQQY32AdDmjFvodsRFz/3ufeoTZ6uYkRFfGo188tENcASNs3vTdsM0w==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/tempy/-/tempy-3.2.0.tgz",
+      "integrity": "sha512-d79HhZya5Djd7am0q+W4RTsSU+D/aJzM+4Y4AGJGuGlgM2L6sx5ZvOYTmZjqPhrDrV6xJTtRSm1JCLj6V6LHLQ==",
       "dev": true,
       "dependencies": {
-        "del": "^6.0.0",
-        "is-stream": "^2.0.0",
-        "temp-dir": "^2.0.0",
-        "type-fest": "^0.16.0",
-        "unique-string": "^2.0.0"
+        "is-stream": "^3.0.0",
+        "temp-dir": "^3.0.0",
+        "type-fest": "^2.12.2",
+        "unique-string": "^3.0.0"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/tempy/node_modules/is-stream": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
+      "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
+      "dev": true,
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/tempy/node_modules/type-fest": {
-      "version": "0.16.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.16.0.tgz",
-      "integrity": "sha512-eaBzG6MxNzEn9kiwvtre90cXaNLkmadMWa1zQMs3XORCXNbsH/OewwbxC5ia9dCxIxnTAsSxXJaa/p5y8DlvJg==",
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
       "dev": true,
       "engines": {
-        "node": ">=10"
+        "node": ">=12.20"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -28349,15 +32274,18 @@
       }
     },
     "node_modules/unique-string": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-2.0.0.tgz",
-      "integrity": "sha512-uNaeirEPvpZWSgzwsPGtU2zVSTrn/8L5q/IexZmH0eH6SA73CmAA5U4GwORTxQAZs95TAXLNqeLoPPNO5gZfWg==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-3.0.0.tgz",
+      "integrity": "sha512-VGXBUVwxKMBUznyffQweQABPRRW1vHZAbadFZud4pLFAqRGvv/96vafgjWFqzourzr8YonlQiPgH0YCJfawoGQ==",
       "dev": true,
       "dependencies": {
-        "crypto-random-string": "^2.0.0"
+        "crypto-random-string": "^4.0.0"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/universal-user-agent": {
@@ -30147,12 +34075,14 @@
       "dev": true
     },
     "@babel/code-frame": {
-      "version": "7.18.6",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.18.6.tgz",
-      "integrity": "sha512-TDCmlK5eOvH+eH7cdAFlNXeVJqWIQ7gW9tY1GJIpUtFb6CmjVyq2VM3u71bOyR8CRihcCgMUYoDNyLXao3+70Q==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
       "dev": true,
       "requires": {
-        "@babel/highlight": "^7.18.6"
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
       }
     },
     "@babel/compat-data": {
@@ -30444,9 +34374,9 @@
       "dev": true
     },
     "@babel/helper-validator-identifier": {
-      "version": "7.18.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.18.6.tgz",
-      "integrity": "sha512-MmetCkz9ej86nJQV+sFCxoGGrUbU3q02kgLciwkrt9QqEB7cP39oKEY0PakknEO0Gu20SskMRi+AYZ3b1TpN9g==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
       "dev": true
     },
     "@babel/helper-validator-option": {
@@ -30476,17 +34406,6 @@
         "@babel/template": "^7.18.6",
         "@babel/traverse": "^7.18.9",
         "@babel/types": "^7.18.9"
-      }
-    },
-    "@babel/highlight": {
-      "version": "7.18.6",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.18.6.tgz",
-      "integrity": "sha512-u7stbOuYjaPezCuLj29hNW1v64M2Md2qupEKP1fHc7WdOA3DgLh37suiSrZYY7haUB7iBeQZ9P1uiRF359do3g==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-validator-identifier": "^7.18.6",
-        "chalk": "^2.0.0",
-        "js-tokens": "^4.0.0"
       }
     },
     "@babel/parser": {
@@ -34567,6 +38486,32 @@
         "esquery": "^1.0.1"
       }
     },
+    "@pnpm/config.env-replace": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@pnpm/config.env-replace/-/config.env-replace-1.1.0.tgz",
+      "integrity": "sha512-htyl8TWnKL7K/ESFa1oW2UB5lVDxuF5DpM7tBi6Hu2LNL3mWkIzNLG6N4zoCUP1lCKNxWy/3iu8mS8MvToGd6w==",
+      "dev": true
+    },
+    "@pnpm/network.ca-file": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@pnpm/network.ca-file/-/network.ca-file-1.0.2.tgz",
+      "integrity": "sha512-YcPQ8a0jwYU9bTdJDpXjMi7Brhkr1mXsXrUJvjqM2mQDgkRiz8jFaQGOdaLxgjtUfQgZhKy/O3cG/YwmgKaxLA==",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "4.2.10"
+      }
+    },
+    "@pnpm/npm-conf": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@pnpm/npm-conf/-/npm-conf-3.0.3.tgz",
+      "integrity": "sha512-//0sR/cow/s4ICQaYoAobOl4aU8cjU6x/V24V7XkKotb9+O+3zySIYp146vpaobYHnxa4pZX8NkV54Z5AwbDKA==",
+      "dev": true,
+      "requires": {
+        "@pnpm/config.env-replace": "^1.1.0",
+        "@pnpm/network.ca-file": "^1.0.1",
+        "config-chain": "^1.1.11"
+      }
+    },
     "@rollup/plugin-json": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/@rollup/plugin-json/-/plugin-json-4.1.0.tgz",
@@ -34814,24 +38759,234 @@
       }
     },
     "@semantic-release/npm": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/@semantic-release/npm/-/npm-9.0.1.tgz",
-      "integrity": "sha512-I5nVZklxBzfMFwemhRNbSrkiN/dsH3c7K9+KSk6jUnq0rdLFUuJt7EBsysq4Ir3moajQgFkfEryEHPqiKJj20g==",
+      "version": "10.0.6",
+      "resolved": "https://registry.npmjs.org/@semantic-release/npm/-/npm-10.0.6.tgz",
+      "integrity": "sha512-DyqHrGE8aUyapA277BB+4kV0C4iMHh3sHzUWdf0jTgp5NNJxVUz76W1f57FB64Ue03him3CBXxFqQD2xGabxow==",
       "dev": true,
       "requires": {
-        "@semantic-release/error": "^3.0.0",
-        "aggregate-error": "^3.0.0",
-        "execa": "^5.0.0",
-        "fs-extra": "^10.0.0",
-        "lodash": "^4.17.15",
+        "@semantic-release/error": "^4.0.0",
+        "aggregate-error": "^5.0.0",
+        "execa": "^8.0.0",
+        "fs-extra": "^11.0.0",
+        "lodash-es": "^4.17.21",
         "nerf-dart": "^1.0.0",
-        "normalize-url": "^6.0.0",
-        "npm": "^8.3.0",
+        "normalize-url": "^8.0.0",
+        "npm": "^9.5.0",
         "rc": "^1.2.8",
-        "read-pkg": "^5.0.0",
-        "registry-auth-token": "^4.0.0",
+        "read-pkg": "^8.0.0",
+        "registry-auth-token": "^5.0.0",
         "semver": "^7.1.2",
-        "tempy": "^1.0.0"
+        "tempy": "^3.0.0"
+      },
+      "dependencies": {
+        "@semantic-release/error": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/@semantic-release/error/-/error-4.0.0.tgz",
+          "integrity": "sha512-mgdxrHTLOjOddRVYIYDo0fR3/v61GNN1YGkfbrjuIKg/uMgCd+Qzo3UAXJ+woLQQpos4pl5Esuw5A7AoNlzjUQ==",
+          "dev": true
+        },
+        "aggregate-error": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-5.0.0.tgz",
+          "integrity": "sha512-gOsf2YwSlleG6IjRYG2A7k0HmBMEo6qVNk9Bp/EaLgAJT5ngH6PXbqa4ItvnEwCm/velL5jAnQgsHsWnjhGmvw==",
+          "dev": true,
+          "requires": {
+            "clean-stack": "^5.2.0",
+            "indent-string": "^5.0.0"
+          }
+        },
+        "clean-stack": {
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-5.3.0.tgz",
+          "integrity": "sha512-9ngPTOhYGQqNVSfeJkYXHmF7AGWp4/nN5D/QqNQs3Dvxd1Kk/WpjHfNujKHYUQ/5CoGyOyFNoWSPk5afzP0QVg==",
+          "dev": true,
+          "requires": {
+            "escape-string-regexp": "5.0.0"
+          }
+        },
+        "escape-string-regexp": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+          "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
+          "dev": true
+        },
+        "execa": {
+          "version": "8.0.1",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-8.0.1.tgz",
+          "integrity": "sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==",
+          "dev": true,
+          "requires": {
+            "cross-spawn": "^7.0.3",
+            "get-stream": "^8.0.1",
+            "human-signals": "^5.0.0",
+            "is-stream": "^3.0.0",
+            "merge-stream": "^2.0.0",
+            "npm-run-path": "^5.1.0",
+            "onetime": "^6.0.0",
+            "signal-exit": "^4.1.0",
+            "strip-final-newline": "^3.0.0"
+          }
+        },
+        "fs-extra": {
+          "version": "11.3.6",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.6.tgz",
+          "integrity": "sha512-w8ZNZr2mKIc7qeNaQ9AVPT1+iFaI+Avd4xudVOvdDJ8VytREi1Ft5Ih7hd9jjehod8vAM5GMsfQ/TpPf4EyoEA==",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.2.0",
+            "jsonfile": "^6.0.1",
+            "universalify": "^2.0.0"
+          }
+        },
+        "get-stream": {
+          "version": "8.0.1",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-8.0.1.tgz",
+          "integrity": "sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==",
+          "dev": true
+        },
+        "hosted-git-info": {
+          "version": "7.0.2",
+          "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-7.0.2.tgz",
+          "integrity": "sha512-puUZAUKT5m8Zzvs72XWy3HtvVbTWljRE66cP60bxJzAqf2DgICo7lYTY2IHUmLnNpjYvw5bvmoHvPc0QO2a62w==",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^10.0.1"
+          }
+        },
+        "human-signals": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-5.0.0.tgz",
+          "integrity": "sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==",
+          "dev": true
+        },
+        "indent-string": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-5.0.0.tgz",
+          "integrity": "sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg==",
+          "dev": true
+        },
+        "is-stream": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
+          "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
+          "dev": true
+        },
+        "json-parse-even-better-errors": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-3.0.2.tgz",
+          "integrity": "sha512-fi0NG4bPjCHunUJffmLd0gxssIgkNmArMvis4iNah6Owg1MCJjWhEcDLmsK6iGkJq3tHwbDkTlce70/tmXN4cQ==",
+          "dev": true
+        },
+        "lines-and-columns": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-2.0.4.tgz",
+          "integrity": "sha512-wM1+Z03eypVAVUCE7QdSqpVIvelbOakn1M0bPDoA4SGWPx3sNDVUiMo3L6To6WWGClB7VyXnhQ4Sn7gxiJbE6A==",
+          "dev": true
+        },
+        "lru-cache": {
+          "version": "10.4.3",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+          "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+          "dev": true
+        },
+        "mimic-fn": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
+          "integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==",
+          "dev": true
+        },
+        "normalize-package-data": {
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-6.0.2.tgz",
+          "integrity": "sha512-V6gygoYb/5EmNI+MEGrWkC+e6+Rr7mTmfHrxDbLzxQogBkgzo76rkok0Am6thgSF7Mv2nLOajAJj5vDJZEFn7g==",
+          "dev": true,
+          "requires": {
+            "hosted-git-info": "^7.0.0",
+            "semver": "^7.3.5",
+            "validate-npm-package-license": "^3.0.4"
+          }
+        },
+        "normalize-url": {
+          "version": "8.1.1",
+          "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-8.1.1.tgz",
+          "integrity": "sha512-JYc0DPlpGWB40kH5g07gGTrYuMqV653k3uBKY6uITPWds3M0ov3GaWGp9lbE3Bzngx8+XkfzgvASb9vk9JDFXQ==",
+          "dev": true
+        },
+        "npm-run-path": {
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.3.0.tgz",
+          "integrity": "sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==",
+          "dev": true,
+          "requires": {
+            "path-key": "^4.0.0"
+          }
+        },
+        "onetime": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
+          "integrity": "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==",
+          "dev": true,
+          "requires": {
+            "mimic-fn": "^4.0.0"
+          }
+        },
+        "parse-json": {
+          "version": "7.1.1",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-7.1.1.tgz",
+          "integrity": "sha512-SgOTCX/EZXtZxBE5eJ97P4yGM5n37BwRU+YMsH4vNzFqJV/oWFXXCmwFlgWUM4PrakybVOueJJ6pwHqSVhTFDw==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.21.4",
+            "error-ex": "^1.3.2",
+            "json-parse-even-better-errors": "^3.0.0",
+            "lines-and-columns": "^2.0.3",
+            "type-fest": "^3.8.0"
+          },
+          "dependencies": {
+            "type-fest": {
+              "version": "3.13.1",
+              "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-3.13.1.tgz",
+              "integrity": "sha512-tLq3bSNx+xSpwvAJnzrK0Ep5CLNWjvFTOp71URMaAEWBfRb9nnJiBoUe0tF8bI4ZFO3omgBR6NvnbzVUT3Ly4g==",
+              "dev": true
+            }
+          }
+        },
+        "path-key": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+          "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
+          "dev": true
+        },
+        "read-pkg": {
+          "version": "8.1.0",
+          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-8.1.0.tgz",
+          "integrity": "sha512-PORM8AgzXeskHO/WEv312k9U03B8K9JSiWF/8N9sUuFjBa+9SF2u6K7VClzXwDXab51jCd8Nd36CNM+zR97ScQ==",
+          "dev": true,
+          "requires": {
+            "@types/normalize-package-data": "^2.4.1",
+            "normalize-package-data": "^6.0.0",
+            "parse-json": "^7.0.0",
+            "type-fest": "^4.2.0"
+          }
+        },
+        "signal-exit": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+          "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+          "dev": true
+        },
+        "strip-final-newline": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
+          "integrity": "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==",
+          "dev": true
+        },
+        "type-fest": {
+          "version": "4.41.0",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+          "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
+          "dev": true
+        }
       }
     },
     "@semantic-release/release-notes-generator": {
@@ -36930,6 +41085,24 @@
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true
     },
+    "config-chain": {
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.13.tgz",
+      "integrity": "sha512-qj+f8APARXHrM0hraqXYb2/bOVSV4PvJQlNZ/DVj0QrmNM2q2euizkeuVckQ57J+W0mRH6Hvi+k50M4Jul2VRQ==",
+      "dev": true,
+      "requires": {
+        "ini": "^1.3.4",
+        "proto-list": "~1.2.1"
+      },
+      "dependencies": {
+        "ini": {
+          "version": "1.3.8",
+          "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+          "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+          "dev": true
+        }
+      }
+    },
     "connect-history-api-fallback": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/connect-history-api-fallback/-/connect-history-api-fallback-2.0.0.tgz",
@@ -37365,10 +41538,21 @@
       "dev": true
     },
     "crypto-random-string": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-2.0.0.tgz",
-      "integrity": "sha512-v1plID3y9r/lPhviJ1wrXpLeyUIGAZ2SHNYTEapm7/8A9nLPoyvVp3RK/EPFqn5kEznyWgYZNsRtYYIWbuG8KA==",
-      "dev": true
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-4.0.0.tgz",
+      "integrity": "sha512-x8dy3RnvYdlUcPOjkEHqozhiwzKNSq7GcPuXFbnyMOCHxX8V3OgIg/pYuabl2sbUPfIJaeAQB7PMOK8DFIdoRA==",
+      "dev": true,
+      "requires": {
+        "type-fest": "^1.0.1"
+      },
+      "dependencies": {
+        "type-fest": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-1.4.0.tgz",
+          "integrity": "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==",
+          "dev": true
+        }
+      }
     },
     "css": {
       "version": "3.0.0",
@@ -42899,6 +47083,12 @@
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "dev": true
     },
+    "lodash-es": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.18.1.tgz",
+      "integrity": "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==",
+      "dev": true
+    },
     "lodash.capitalize": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/lodash.capitalize/-/lodash.capitalize-4.2.1.tgz",
@@ -43877,81 +48067,81 @@
       "dev": true
     },
     "npm": {
-      "version": "8.12.1",
-      "resolved": "https://registry.npmjs.org/npm/-/npm-8.12.1.tgz",
-      "integrity": "sha512-0yOlhfgu1UzP6UijnaFuIS2bES2H9D90EA5OVsf2iOZw7VBrjntXKEwKfCaFA6vMVWkCP8qnPwCxxPdnDVwlNw==",
+      "version": "9.9.4",
+      "resolved": "https://registry.npmjs.org/npm/-/npm-9.9.4.tgz",
+      "integrity": "sha512-NzcQiLpqDuLhavdyJ2J3tGJ/ni/ebcqHVFZkv1C4/6lblraUPbPgCJ4Vhb4oa3FFhRa2Yj9gA58jGH/ztKueNQ==",
       "dev": true,
       "requires": {
         "@isaacs/string-locale-compare": "^1.1.0",
-        "@npmcli/arborist": "^5.0.4",
-        "@npmcli/ci-detect": "^2.0.0",
-        "@npmcli/config": "^4.1.0",
-        "@npmcli/fs": "^2.1.0",
-        "@npmcli/map-workspaces": "^2.0.3",
-        "@npmcli/package-json": "^2.0.0",
-        "@npmcli/run-script": "^3.0.1",
-        "abbrev": "~1.1.1",
+        "@npmcli/arborist": "^6.5.0",
+        "@npmcli/config": "^6.4.0",
+        "@npmcli/fs": "^3.1.0",
+        "@npmcli/map-workspaces": "^3.0.4",
+        "@npmcli/package-json": "^4.0.1",
+        "@npmcli/promise-spawn": "^6.0.2",
+        "@npmcli/run-script": "^6.0.2",
+        "abbrev": "^2.0.0",
         "archy": "~1.0.0",
-        "cacache": "^16.1.0",
-        "chalk": "^4.1.2",
-        "chownr": "^2.0.0",
+        "cacache": "^17.1.4",
+        "chalk": "^5.3.0",
+        "ci-info": "^4.0.0",
         "cli-columns": "^4.0.0",
-        "cli-table3": "^0.6.2",
+        "cli-table3": "^0.6.3",
         "columnify": "^1.6.0",
-        "fastest-levenshtein": "^1.0.12",
-        "glob": "^8.0.1",
-        "graceful-fs": "^4.2.10",
-        "hosted-git-info": "^5.0.0",
-        "ini": "^3.0.0",
-        "init-package-json": "^3.0.2",
+        "fastest-levenshtein": "^1.0.16",
+        "fs-minipass": "^3.0.3",
+        "glob": "^10.3.10",
+        "graceful-fs": "^4.2.11",
+        "hosted-git-info": "^6.1.3",
+        "ini": "^4.1.1",
+        "init-package-json": "^5.0.0",
         "is-cidr": "^4.0.2",
-        "json-parse-even-better-errors": "^2.3.1",
-        "libnpmaccess": "^6.0.2",
-        "libnpmdiff": "^4.0.2",
-        "libnpmexec": "^4.0.2",
-        "libnpmfund": "^3.0.1",
-        "libnpmhook": "^8.0.2",
-        "libnpmorg": "^4.0.2",
-        "libnpmpack": "^4.0.2",
-        "libnpmpublish": "^6.0.2",
-        "libnpmsearch": "^5.0.2",
-        "libnpmteam": "^4.0.2",
-        "libnpmversion": "^3.0.1",
-        "make-fetch-happen": "^10.1.6",
-        "minipass": "^3.1.6",
+        "json-parse-even-better-errors": "^3.0.1",
+        "libnpmaccess": "^7.0.2",
+        "libnpmdiff": "^5.0.20",
+        "libnpmexec": "^6.0.4",
+        "libnpmfund": "^4.2.1",
+        "libnpmhook": "^9.0.3",
+        "libnpmorg": "^5.0.4",
+        "libnpmpack": "^5.0.20",
+        "libnpmpublish": "^7.5.1",
+        "libnpmsearch": "^6.0.2",
+        "libnpmteam": "^5.0.3",
+        "libnpmversion": "^4.0.2",
+        "make-fetch-happen": "^11.1.1",
+        "minimatch": "^9.0.3",
+        "minipass": "^7.0.4",
         "minipass-pipeline": "^1.2.4",
-        "mkdirp": "^1.0.4",
-        "mkdirp-infer-owner": "^2.0.0",
         "ms": "^2.1.2",
-        "node-gyp": "^9.0.0",
-        "nopt": "^5.0.0",
-        "npm-audit-report": "^3.0.0",
-        "npm-install-checks": "^5.0.0",
-        "npm-package-arg": "^9.0.2",
-        "npm-pick-manifest": "^7.0.1",
-        "npm-profile": "^6.0.3",
-        "npm-registry-fetch": "^13.1.1",
-        "npm-user-validate": "^1.0.1",
-        "npmlog": "^6.0.2",
-        "opener": "^1.5.2",
-        "pacote": "^13.6.0",
-        "parse-conflict-json": "^2.0.2",
-        "proc-log": "^2.0.1",
+        "node-gyp": "^9.4.1",
+        "nopt": "^7.2.0",
+        "normalize-package-data": "^5.0.0",
+        "npm-audit-report": "^5.0.0",
+        "npm-install-checks": "^6.3.0",
+        "npm-package-arg": "^10.1.0",
+        "npm-pick-manifest": "^8.0.2",
+        "npm-profile": "^7.0.1",
+        "npm-registry-fetch": "^14.0.5",
+        "npm-user-validate": "^2.0.0",
+        "npmlog": "^7.0.1",
+        "p-map": "^4.0.0",
+        "pacote": "^15.2.0",
+        "parse-conflict-json": "^3.0.1",
+        "proc-log": "^3.0.0",
         "qrcode-terminal": "^0.12.0",
-        "read": "~1.0.7",
-        "read-package-json": "^5.0.1",
-        "read-package-json-fast": "^2.0.3",
-        "readdir-scoped-modules": "^1.1.0",
-        "rimraf": "^3.0.2",
-        "semver": "^7.3.7",
-        "ssri": "^9.0.1",
-        "tar": "^6.1.11",
+        "read": "^2.1.0",
+        "semver": "^7.6.0",
+        "sigstore": "^1.9.0",
+        "spdx-expression-parse": "^3.0.1",
+        "ssri": "^10.0.5",
+        "supports-color": "^9.4.0",
+        "tar": "^6.2.1",
         "text-table": "~0.2.0",
         "tiny-relative-date": "^1.3.0",
-        "treeverse": "^2.0.0",
-        "validate-npm-package-name": "^4.0.0",
-        "which": "^2.0.2",
-        "write-file-atomic": "^4.0.1"
+        "treeverse": "^3.0.0",
+        "validate-npm-package-name": "^5.0.0",
+        "which": "^3.0.1",
+        "write-file-atomic": "^5.0.1"
       },
       "dependencies": {
         "@colors/colors": {
@@ -43965,74 +48155,111 @@
           "bundled": true,
           "dev": true
         },
+        "@isaacs/cliui": {
+          "version": "8.0.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "string-width": "^5.1.2",
+            "string-width-cjs": "npm:string-width@^4.2.0",
+            "strip-ansi": "^7.0.1",
+            "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+            "wrap-ansi": "^8.1.0",
+            "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+          },
+          "dependencies": {
+            "ansi-regex": {
+              "version": "6.0.1",
+              "bundled": true,
+              "dev": true
+            },
+            "emoji-regex": {
+              "version": "9.2.2",
+              "bundled": true,
+              "dev": true
+            },
+            "string-width": {
+              "version": "5.1.2",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "eastasianwidth": "^0.2.0",
+                "emoji-regex": "^9.2.2",
+                "strip-ansi": "^7.0.1"
+              }
+            },
+            "strip-ansi": {
+              "version": "7.1.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "ansi-regex": "^6.0.1"
+              }
+            }
+          }
+        },
         "@isaacs/string-locale-compare": {
           "version": "1.1.0",
           "bundled": true,
           "dev": true
         },
         "@npmcli/arborist": {
-          "version": "5.2.1",
+          "version": "6.5.1",
           "bundled": true,
           "dev": true,
           "requires": {
             "@isaacs/string-locale-compare": "^1.1.0",
-            "@npmcli/installed-package-contents": "^1.0.7",
-            "@npmcli/map-workspaces": "^2.0.3",
-            "@npmcli/metavuln-calculator": "^3.0.1",
-            "@npmcli/move-file": "^2.0.0",
-            "@npmcli/name-from-folder": "^1.0.1",
-            "@npmcli/node-gyp": "^2.0.0",
-            "@npmcli/package-json": "^2.0.0",
-            "@npmcli/run-script": "^3.0.0",
-            "bin-links": "^3.0.0",
-            "cacache": "^16.0.6",
+            "@npmcli/fs": "^3.1.0",
+            "@npmcli/installed-package-contents": "^2.0.2",
+            "@npmcli/map-workspaces": "^3.0.2",
+            "@npmcli/metavuln-calculator": "^5.0.0",
+            "@npmcli/name-from-folder": "^2.0.0",
+            "@npmcli/node-gyp": "^3.0.0",
+            "@npmcli/package-json": "^4.0.0",
+            "@npmcli/query": "^3.1.0",
+            "@npmcli/run-script": "^6.0.0",
+            "bin-links": "^4.0.1",
+            "cacache": "^17.0.4",
             "common-ancestor-path": "^1.0.1",
-            "json-parse-even-better-errors": "^2.3.1",
+            "hosted-git-info": "^6.1.1",
+            "json-parse-even-better-errors": "^3.0.0",
             "json-stringify-nice": "^1.1.4",
-            "mkdirp": "^1.0.4",
-            "mkdirp-infer-owner": "^2.0.0",
-            "nopt": "^5.0.0",
-            "npm-install-checks": "^5.0.0",
-            "npm-package-arg": "^9.0.0",
-            "npm-pick-manifest": "^7.0.0",
-            "npm-registry-fetch": "^13.0.0",
-            "npmlog": "^6.0.2",
-            "pacote": "^13.0.5",
-            "parse-conflict-json": "^2.0.1",
-            "proc-log": "^2.0.0",
+            "minimatch": "^9.0.0",
+            "nopt": "^7.0.0",
+            "npm-install-checks": "^6.2.0",
+            "npm-package-arg": "^10.1.0",
+            "npm-pick-manifest": "^8.0.1",
+            "npm-registry-fetch": "^14.0.3",
+            "npmlog": "^7.0.1",
+            "pacote": "^15.0.8",
+            "parse-conflict-json": "^3.0.0",
+            "proc-log": "^3.0.0",
             "promise-all-reject-late": "^1.0.0",
-            "promise-call-limit": "^1.0.1",
-            "read-package-json-fast": "^2.0.2",
-            "readdir-scoped-modules": "^1.1.0",
-            "rimraf": "^3.0.2",
+            "promise-call-limit": "^1.0.2",
+            "read-package-json-fast": "^3.0.2",
             "semver": "^7.3.7",
-            "ssri": "^9.0.0",
-            "treeverse": "^2.0.0",
-            "walk-up-path": "^1.0.0"
+            "ssri": "^10.0.1",
+            "treeverse": "^3.0.0",
+            "walk-up-path": "^3.0.1"
           }
         },
-        "@npmcli/ci-detect": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dev": true
-        },
         "@npmcli/config": {
-          "version": "4.1.0",
+          "version": "6.4.1",
           "bundled": true,
           "dev": true,
           "requires": {
-            "@npmcli/map-workspaces": "^2.0.2",
-            "ini": "^3.0.0",
-            "mkdirp-infer-owner": "^2.0.0",
-            "nopt": "^5.0.0",
-            "proc-log": "^2.0.0",
-            "read-package-json-fast": "^2.0.3",
+            "@npmcli/map-workspaces": "^3.0.2",
+            "ci-info": "^4.0.0",
+            "ini": "^4.1.0",
+            "nopt": "^7.0.0",
+            "proc-log": "^3.0.0",
+            "read-package-json-fast": "^3.0.2",
             "semver": "^7.3.5",
-            "walk-up-path": "^1.0.0"
+            "walk-up-path": "^3.0.1"
           }
         },
         "@npmcli/disparity-colors": {
-          "version": "2.0.0",
+          "version": "3.0.0",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -44040,63 +48267,61 @@
           }
         },
         "@npmcli/fs": {
-          "version": "2.1.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "@gar/promisify": "^1.1.3",
-            "semver": "^7.3.5"
-          }
-        },
-        "@npmcli/git": {
-          "version": "3.0.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "@npmcli/promise-spawn": "^3.0.0",
-            "lru-cache": "^7.4.4",
-            "mkdirp": "^1.0.4",
-            "npm-pick-manifest": "^7.0.0",
-            "proc-log": "^2.0.0",
-            "promise-inflight": "^1.0.1",
-            "promise-retry": "^2.0.1",
-            "semver": "^7.3.5",
-            "which": "^2.0.2"
-          }
-        },
-        "@npmcli/installed-package-contents": {
-          "version": "1.0.7",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "npm-bundled": "^1.1.1",
-            "npm-normalize-package-bin": "^1.0.1"
-          }
-        },
-        "@npmcli/map-workspaces": {
-          "version": "2.0.3",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "@npmcli/name-from-folder": "^1.0.1",
-            "glob": "^8.0.1",
-            "minimatch": "^5.0.1",
-            "read-package-json-fast": "^2.0.3"
-          }
-        },
-        "@npmcli/metavuln-calculator": {
           "version": "3.1.0",
           "bundled": true,
           "dev": true,
           "requires": {
-            "cacache": "^16.0.0",
-            "json-parse-even-better-errors": "^2.3.1",
-            "pacote": "^13.0.3",
+            "semver": "^7.3.5"
+          }
+        },
+        "@npmcli/git": {
+          "version": "4.1.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "@npmcli/promise-spawn": "^6.0.0",
+            "lru-cache": "^7.4.4",
+            "npm-pick-manifest": "^8.0.0",
+            "proc-log": "^3.0.0",
+            "promise-inflight": "^1.0.1",
+            "promise-retry": "^2.0.1",
+            "semver": "^7.3.5",
+            "which": "^3.0.0"
+          }
+        },
+        "@npmcli/installed-package-contents": {
+          "version": "2.0.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "npm-bundled": "^3.0.0",
+            "npm-normalize-package-bin": "^3.0.0"
+          }
+        },
+        "@npmcli/map-workspaces": {
+          "version": "3.0.4",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "@npmcli/name-from-folder": "^2.0.0",
+            "glob": "^10.2.2",
+            "minimatch": "^9.0.0",
+            "read-package-json-fast": "^3.0.0"
+          }
+        },
+        "@npmcli/metavuln-calculator": {
+          "version": "5.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "cacache": "^17.0.0",
+            "json-parse-even-better-errors": "^3.0.0",
+            "pacote": "^15.0.0",
             "semver": "^7.3.5"
           }
         },
         "@npmcli/move-file": {
-          "version": "2.0.0",
+          "version": "2.0.1",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -44105,40 +48330,93 @@
           }
         },
         "@npmcli/name-from-folder": {
-          "version": "1.0.1",
+          "version": "2.0.0",
           "bundled": true,
           "dev": true
         },
         "@npmcli/node-gyp": {
-          "version": "2.0.0",
+          "version": "3.0.0",
           "bundled": true,
           "dev": true
         },
         "@npmcli/package-json": {
-          "version": "2.0.0",
+          "version": "4.0.1",
           "bundled": true,
           "dev": true,
           "requires": {
-            "json-parse-even-better-errors": "^2.3.1"
+            "@npmcli/git": "^4.1.0",
+            "glob": "^10.2.2",
+            "hosted-git-info": "^6.1.1",
+            "json-parse-even-better-errors": "^3.0.0",
+            "normalize-package-data": "^5.0.0",
+            "proc-log": "^3.0.0",
+            "semver": "^7.5.3"
           }
         },
         "@npmcli/promise-spawn": {
-          "version": "3.0.0",
+          "version": "6.0.2",
           "bundled": true,
           "dev": true,
           "requires": {
-            "infer-owner": "^1.0.4"
+            "which": "^3.0.0"
+          }
+        },
+        "@npmcli/query": {
+          "version": "3.1.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "postcss-selector-parser": "^6.0.10"
           }
         },
         "@npmcli/run-script": {
-          "version": "3.0.2",
+          "version": "6.0.2",
           "bundled": true,
           "dev": true,
           "requires": {
-            "@npmcli/node-gyp": "^2.0.0",
-            "@npmcli/promise-spawn": "^3.0.0",
+            "@npmcli/node-gyp": "^3.0.0",
+            "@npmcli/promise-spawn": "^6.0.0",
             "node-gyp": "^9.0.0",
-            "read-package-json-fast": "^2.0.3"
+            "read-package-json-fast": "^3.0.0",
+            "which": "^3.0.0"
+          }
+        },
+        "@pkgjs/parseargs": {
+          "version": "0.11.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "@sigstore/bundle": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "@sigstore/protobuf-specs": "^0.2.0"
+          }
+        },
+        "@sigstore/protobuf-specs": {
+          "version": "0.2.1",
+          "bundled": true,
+          "dev": true
+        },
+        "@sigstore/sign": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "@sigstore/bundle": "^1.1.0",
+            "@sigstore/protobuf-specs": "^0.2.0",
+            "make-fetch-happen": "^11.0.1"
+          }
+        },
+        "@sigstore/tuf": {
+          "version": "1.0.3",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "@sigstore/protobuf-specs": "^0.2.0",
+            "tuf-js": "^1.1.7"
           }
         },
         "@tootallnate/once": {
@@ -44146,8 +48424,22 @@
           "bundled": true,
           "dev": true
         },
+        "@tufjs/canonical-json": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "@tufjs/models": {
+          "version": "1.0.4",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "@tufjs/canonical-json": "1.0.0",
+            "minimatch": "^9.0.0"
+          }
+        },
         "abbrev": {
-          "version": "1.1.1",
+          "version": "2.0.0",
           "bundled": true,
           "dev": true
         },
@@ -44160,12 +48452,10 @@
           }
         },
         "agentkeepalive": {
-          "version": "4.2.1",
+          "version": "4.5.0",
           "bundled": true,
           "dev": true,
           "requires": {
-            "debug": "^4.1.0",
-            "depd": "^1.1.2",
             "humanize-ms": "^1.2.1"
           }
         },
@@ -44202,16 +48492,7 @@
           "dev": true
         },
         "are-we-there-yet": {
-          "version": "3.0.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "delegates": "^1.0.0",
-            "readable-stream": "^3.6.0"
-          }
-        },
-        "asap": {
-          "version": "2.0.6",
+          "version": "4.0.2",
           "bundled": true,
           "dev": true
         },
@@ -44221,16 +48502,14 @@
           "dev": true
         },
         "bin-links": {
-          "version": "3.0.1",
+          "version": "4.0.3",
           "bundled": true,
           "dev": true,
           "requires": {
-            "cmd-shim": "^5.0.0",
-            "mkdirp-infer-owner": "^2.0.0",
-            "npm-normalize-package-bin": "^1.0.0",
-            "read-cmd-shim": "^3.0.0",
-            "rimraf": "^3.0.0",
-            "write-file-atomic": "^4.0.0"
+            "cmd-shim": "^6.0.0",
+            "npm-normalize-package-bin": "^3.0.0",
+            "read-cmd-shim": "^4.0.0",
+            "write-file-atomic": "^5.0.0"
           }
         },
         "binary-extensions": {
@@ -44255,41 +48534,36 @@
           }
         },
         "cacache": {
-          "version": "16.1.0",
+          "version": "17.1.4",
           "bundled": true,
           "dev": true,
           "requires": {
-            "@npmcli/fs": "^2.1.0",
-            "@npmcli/move-file": "^2.0.0",
-            "chownr": "^2.0.0",
-            "fs-minipass": "^2.1.0",
-            "glob": "^8.0.1",
-            "infer-owner": "^1.0.4",
+            "@npmcli/fs": "^3.1.0",
+            "fs-minipass": "^3.0.0",
+            "glob": "^10.2.2",
             "lru-cache": "^7.7.1",
-            "minipass": "^3.1.6",
+            "minipass": "^7.0.3",
             "minipass-collect": "^1.0.2",
             "minipass-flush": "^1.0.5",
             "minipass-pipeline": "^1.2.4",
-            "mkdirp": "^1.0.4",
             "p-map": "^4.0.0",
-            "promise-inflight": "^1.0.1",
-            "rimraf": "^3.0.2",
-            "ssri": "^9.0.0",
+            "ssri": "^10.0.0",
             "tar": "^6.1.11",
-            "unique-filename": "^1.1.1"
+            "unique-filename": "^3.0.0"
           }
         },
         "chalk": {
-          "version": "4.1.2",
+          "version": "5.3.0",
           "bundled": true,
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^4.1.0",
-            "supports-color": "^7.1.0"
-          }
+          "dev": true
         },
         "chownr": {
           "version": "2.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "ci-info": {
+          "version": "4.0.0",
           "bundled": true,
           "dev": true
         },
@@ -44316,7 +48590,7 @@
           }
         },
         "cli-table3": {
-          "version": "0.6.2",
+          "version": "0.6.3",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -44330,12 +48604,9 @@
           "dev": true
         },
         "cmd-shim": {
-          "version": "5.0.0",
+          "version": "6.0.2",
           "bundled": true,
-          "dev": true,
-          "requires": {
-            "mkdirp-infer-owner": "^2.0.0"
-          }
+          "dev": true
         },
         "color-convert": {
           "version": "2.0.1",
@@ -44379,28 +48650,41 @@
           "bundled": true,
           "dev": true
         },
-        "debug": {
-          "version": "4.3.4",
+        "cross-spawn": {
+          "version": "7.0.6",
           "bundled": true,
           "dev": true,
           "requires": {
-            "ms": "2.1.2"
+            "path-key": "^3.1.0",
+            "shebang-command": "^2.0.0",
+            "which": "^2.0.1"
           },
           "dependencies": {
-            "ms": {
-              "version": "2.1.2",
+            "which": {
+              "version": "2.0.2",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "requires": {
+                "isexe": "^2.0.0"
+              }
             }
           }
         },
-        "debuglog": {
-          "version": "1.0.1",
+        "cssesc": {
+          "version": "3.0.0",
           "bundled": true,
           "dev": true
         },
+        "debug": {
+          "version": "4.3.7",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.3"
+          }
+        },
         "defaults": {
-          "version": "1.0.3",
+          "version": "1.0.4",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -44412,22 +48696,13 @@
           "bundled": true,
           "dev": true
         },
-        "depd": {
-          "version": "1.1.2",
+        "diff": {
+          "version": "5.2.0",
           "bundled": true,
           "dev": true
         },
-        "dezalgo": {
-          "version": "1.0.4",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "asap": "^2.0.0",
-            "wrappy": "1"
-          }
-        },
-        "diff": {
-          "version": "5.0.0",
+        "eastasianwidth": {
+          "version": "0.2.0",
           "bundled": true,
           "dev": true
         },
@@ -44455,17 +48730,31 @@
           "bundled": true,
           "dev": true
         },
-        "fastest-levenshtein": {
-          "version": "1.0.12",
+        "exponential-backoff": {
+          "version": "3.1.1",
           "bundled": true,
           "dev": true
         },
-        "fs-minipass": {
-          "version": "2.1.0",
+        "fastest-levenshtein": {
+          "version": "1.0.16",
+          "bundled": true,
+          "dev": true
+        },
+        "foreground-child": {
+          "version": "3.1.1",
           "bundled": true,
           "dev": true,
           "requires": {
-            "minipass": "^3.0.0"
+            "cross-spawn": "^7.0.0",
+            "signal-exit": "^4.0.1"
+          }
+        },
+        "fs-minipass": {
+          "version": "3.0.3",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "minipass": "^7.0.3"
           }
         },
         "fs.realpath": {
@@ -44474,12 +48763,12 @@
           "dev": true
         },
         "function-bind": {
-          "version": "1.1.1",
+          "version": "1.1.2",
           "bundled": true,
           "dev": true
         },
         "gauge": {
-          "version": "4.0.4",
+          "version": "5.0.1",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -44487,39 +48776,26 @@
             "color-support": "^1.1.3",
             "console-control-strings": "^1.1.0",
             "has-unicode": "^2.0.1",
-            "signal-exit": "^3.0.7",
+            "signal-exit": "^4.0.1",
             "string-width": "^4.2.3",
             "strip-ansi": "^6.0.1",
             "wide-align": "^1.1.5"
           }
         },
         "glob": {
-          "version": "8.0.3",
+          "version": "10.3.10",
           "bundled": true,
           "dev": true,
           "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^5.0.1",
-            "once": "^1.3.0"
+            "foreground-child": "^3.1.0",
+            "jackspeak": "^2.3.5",
+            "minimatch": "^9.0.1",
+            "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0",
+            "path-scurry": "^1.10.1"
           }
         },
         "graceful-fs": {
-          "version": "4.2.10",
-          "bundled": true,
-          "dev": true
-        },
-        "has": {
-          "version": "1.0.3",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "function-bind": "^1.1.1"
-          }
-        },
-        "has-flag": {
-          "version": "4.0.0",
+          "version": "4.2.11",
           "bundled": true,
           "dev": true
         },
@@ -44528,8 +48804,16 @@
           "bundled": true,
           "dev": true
         },
+        "hasown": {
+          "version": "2.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "function-bind": "^1.1.2"
+          }
+        },
         "hosted-git-info": {
-          "version": "5.0.0",
+          "version": "6.1.3",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -44537,7 +48821,7 @@
           }
         },
         "http-cache-semantics": {
-          "version": "4.1.0",
+          "version": "4.1.1",
           "bundled": true,
           "dev": true
         },
@@ -44578,11 +48862,11 @@
           }
         },
         "ignore-walk": {
-          "version": "5.0.1",
+          "version": "6.0.4",
           "bundled": true,
           "dev": true,
           "requires": {
-            "minimatch": "^5.0.1"
+            "minimatch": "^9.0.0"
           }
         },
         "imurmurhash": {
@@ -44615,28 +48899,39 @@
           "dev": true
         },
         "ini": {
-          "version": "3.0.0",
+          "version": "4.1.1",
           "bundled": true,
           "dev": true
         },
         "init-package-json": {
-          "version": "3.0.2",
+          "version": "5.0.0",
           "bundled": true,
           "dev": true,
           "requires": {
-            "npm-package-arg": "^9.0.1",
-            "promzard": "^0.3.0",
-            "read": "^1.0.7",
-            "read-package-json": "^5.0.0",
+            "npm-package-arg": "^10.0.0",
+            "promzard": "^1.0.0",
+            "read": "^2.0.0",
+            "read-package-json": "^6.0.0",
             "semver": "^7.3.5",
             "validate-npm-package-license": "^3.0.4",
-            "validate-npm-package-name": "^4.0.0"
+            "validate-npm-package-name": "^5.0.0"
           }
         },
-        "ip": {
-          "version": "1.1.8",
+        "ip-address": {
+          "version": "9.0.5",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "jsbn": "1.1.0",
+            "sprintf-js": "^1.1.3"
+          },
+          "dependencies": {
+            "sprintf-js": {
+              "version": "1.1.3",
+              "bundled": true,
+              "dev": true
+            }
+          }
         },
         "ip-regex": {
           "version": "4.3.0",
@@ -44652,11 +48947,11 @@
           }
         },
         "is-core-module": {
-          "version": "2.9.0",
+          "version": "2.13.1",
           "bundled": true,
           "dev": true,
           "requires": {
-            "has": "^1.0.3"
+            "hasown": "^2.0.0"
           }
         },
         "is-fullwidth-code-point": {
@@ -44674,8 +48969,22 @@
           "bundled": true,
           "dev": true
         },
+        "jackspeak": {
+          "version": "2.3.6",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "@isaacs/cliui": "^8.0.2",
+            "@pkgjs/parseargs": "^0.11.0"
+          }
+        },
+        "jsbn": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true
+        },
         "json-parse-even-better-errors": {
-          "version": "2.3.1",
+          "version": "3.0.1",
           "bundled": true,
           "dev": true
         },
@@ -44690,167 +48999,175 @@
           "dev": true
         },
         "just-diff": {
-          "version": "5.0.2",
+          "version": "6.0.2",
           "bundled": true,
           "dev": true
         },
         "just-diff-apply": {
-          "version": "5.2.0",
+          "version": "5.5.0",
           "bundled": true,
           "dev": true
         },
         "libnpmaccess": {
+          "version": "7.0.3",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "npm-package-arg": "^10.1.0",
+            "npm-registry-fetch": "^14.0.3"
+          }
+        },
+        "libnpmdiff": {
+          "version": "5.0.21",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "@npmcli/arborist": "^6.5.0",
+            "@npmcli/disparity-colors": "^3.0.0",
+            "@npmcli/installed-package-contents": "^2.0.2",
+            "binary-extensions": "^2.2.0",
+            "diff": "^5.1.0",
+            "minimatch": "^9.0.0",
+            "npm-package-arg": "^10.1.0",
+            "pacote": "^15.0.8",
+            "tar": "^6.1.13"
+          }
+        },
+        "libnpmexec": {
+          "version": "6.0.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "@npmcli/arborist": "^6.5.0",
+            "@npmcli/run-script": "^6.0.0",
+            "ci-info": "^4.0.0",
+            "npm-package-arg": "^10.1.0",
+            "npmlog": "^7.0.1",
+            "pacote": "^15.0.8",
+            "proc-log": "^3.0.0",
+            "read": "^2.0.0",
+            "read-package-json-fast": "^3.0.2",
+            "semver": "^7.3.7",
+            "walk-up-path": "^3.0.1"
+          }
+        },
+        "libnpmfund": {
+          "version": "4.2.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "@npmcli/arborist": "^6.5.0"
+          }
+        },
+        "libnpmhook": {
+          "version": "9.0.4",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "aproba": "^2.0.0",
+            "npm-registry-fetch": "^14.0.3"
+          }
+        },
+        "libnpmorg": {
+          "version": "5.0.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "aproba": "^2.0.0",
+            "npm-registry-fetch": "^14.0.3"
+          }
+        },
+        "libnpmpack": {
+          "version": "5.0.21",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "@npmcli/arborist": "^6.5.0",
+            "@npmcli/run-script": "^6.0.0",
+            "npm-package-arg": "^10.1.0",
+            "pacote": "^15.0.8"
+          }
+        },
+        "libnpmpublish": {
+          "version": "7.5.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "ci-info": "^4.0.0",
+            "normalize-package-data": "^5.0.0",
+            "npm-package-arg": "^10.1.0",
+            "npm-registry-fetch": "^14.0.3",
+            "proc-log": "^3.0.0",
+            "semver": "^7.3.7",
+            "sigstore": "^1.4.0",
+            "ssri": "^10.0.1"
+          }
+        },
+        "libnpmsearch": {
           "version": "6.0.3",
           "bundled": true,
           "dev": true,
           "requires": {
-            "aproba": "^2.0.0",
-            "minipass": "^3.1.1",
-            "npm-package-arg": "^9.0.1",
-            "npm-registry-fetch": "^13.0.0"
-          }
-        },
-        "libnpmdiff": {
-          "version": "4.0.3",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "@npmcli/disparity-colors": "^2.0.0",
-            "@npmcli/installed-package-contents": "^1.0.7",
-            "binary-extensions": "^2.2.0",
-            "diff": "^5.0.0",
-            "minimatch": "^5.0.1",
-            "npm-package-arg": "^9.0.1",
-            "pacote": "^13.0.5",
-            "tar": "^6.1.0"
-          }
-        },
-        "libnpmexec": {
-          "version": "4.0.6",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "@npmcli/arborist": "^5.0.0",
-            "@npmcli/ci-detect": "^2.0.0",
-            "@npmcli/run-script": "^3.0.0",
-            "chalk": "^4.1.0",
-            "mkdirp-infer-owner": "^2.0.0",
-            "npm-package-arg": "^9.0.1",
-            "npmlog": "^6.0.2",
-            "pacote": "^13.0.5",
-            "proc-log": "^2.0.0",
-            "read": "^1.0.7",
-            "read-package-json-fast": "^2.0.2",
-            "walk-up-path": "^1.0.0"
-          }
-        },
-        "libnpmfund": {
-          "version": "3.0.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "@npmcli/arborist": "^5.0.0"
-          }
-        },
-        "libnpmhook": {
-          "version": "8.0.3",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "aproba": "^2.0.0",
-            "npm-registry-fetch": "^13.0.0"
-          }
-        },
-        "libnpmorg": {
-          "version": "4.0.3",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "aproba": "^2.0.0",
-            "npm-registry-fetch": "^13.0.0"
-          }
-        },
-        "libnpmpack": {
-          "version": "4.1.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "@npmcli/run-script": "^3.0.0",
-            "npm-package-arg": "^9.0.1",
-            "pacote": "^13.5.0"
-          }
-        },
-        "libnpmpublish": {
-          "version": "6.0.4",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "normalize-package-data": "^4.0.0",
-            "npm-package-arg": "^9.0.1",
-            "npm-registry-fetch": "^13.0.0",
-            "semver": "^7.3.7",
-            "ssri": "^9.0.0"
-          }
-        },
-        "libnpmsearch": {
-          "version": "5.0.3",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "npm-registry-fetch": "^13.0.0"
+            "npm-registry-fetch": "^14.0.3"
           }
         },
         "libnpmteam": {
-          "version": "4.0.3",
+          "version": "5.0.4",
           "bundled": true,
           "dev": true,
           "requires": {
             "aproba": "^2.0.0",
-            "npm-registry-fetch": "^13.0.0"
+            "npm-registry-fetch": "^14.0.3"
           }
         },
         "libnpmversion": {
-          "version": "3.0.4",
+          "version": "4.0.3",
           "bundled": true,
           "dev": true,
           "requires": {
-            "@npmcli/git": "^3.0.0",
-            "@npmcli/run-script": "^3.0.0",
-            "json-parse-even-better-errors": "^2.3.1",
-            "proc-log": "^2.0.0",
+            "@npmcli/git": "^4.0.1",
+            "@npmcli/run-script": "^6.0.0",
+            "json-parse-even-better-errors": "^3.0.0",
+            "proc-log": "^3.0.0",
             "semver": "^7.3.7"
           }
         },
         "lru-cache": {
-          "version": "7.9.0",
+          "version": "7.18.3",
           "bundled": true,
           "dev": true
         },
         "make-fetch-happen": {
-          "version": "10.1.6",
+          "version": "11.1.1",
           "bundled": true,
           "dev": true,
           "requires": {
             "agentkeepalive": "^4.2.1",
-            "cacache": "^16.1.0",
-            "http-cache-semantics": "^4.1.0",
+            "cacache": "^17.0.0",
+            "http-cache-semantics": "^4.1.1",
             "http-proxy-agent": "^5.0.0",
             "https-proxy-agent": "^5.0.0",
             "is-lambda": "^1.0.1",
             "lru-cache": "^7.7.1",
-            "minipass": "^3.1.6",
-            "minipass-collect": "^1.0.2",
-            "minipass-fetch": "^2.0.3",
+            "minipass": "^5.0.0",
+            "minipass-fetch": "^3.0.0",
             "minipass-flush": "^1.0.5",
             "minipass-pipeline": "^1.2.4",
             "negotiator": "^0.6.3",
             "promise-retry": "^2.0.1",
-            "socks-proxy-agent": "^6.1.1",
-            "ssri": "^9.0.0"
+            "socks-proxy-agent": "^7.0.0",
+            "ssri": "^10.0.0"
+          },
+          "dependencies": {
+            "minipass": {
+              "version": "5.0.0",
+              "bundled": true,
+              "dev": true
+            }
           }
         },
         "minimatch": {
-          "version": "5.1.0",
+          "version": "9.0.3",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -44858,12 +49175,9 @@
           }
         },
         "minipass": {
-          "version": "3.1.6",
+          "version": "7.0.4",
           "bundled": true,
-          "dev": true,
-          "requires": {
-            "yallist": "^4.0.0"
-          }
+          "dev": true
         },
         "minipass-collect": {
           "version": "1.0.2",
@@ -44871,15 +49185,25 @@
           "dev": true,
           "requires": {
             "minipass": "^3.0.0"
+          },
+          "dependencies": {
+            "minipass": {
+              "version": "3.3.6",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "yallist": "^4.0.0"
+              }
+            }
           }
         },
         "minipass-fetch": {
-          "version": "2.1.0",
+          "version": "3.0.4",
           "bundled": true,
           "dev": true,
           "requires": {
             "encoding": "^0.1.13",
-            "minipass": "^3.1.6",
+            "minipass": "^7.0.3",
             "minipass-sized": "^1.0.3",
             "minizlib": "^2.1.2"
           }
@@ -44890,6 +49214,16 @@
           "dev": true,
           "requires": {
             "minipass": "^3.0.0"
+          },
+          "dependencies": {
+            "minipass": {
+              "version": "3.3.6",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "yallist": "^4.0.0"
+              }
+            }
           }
         },
         "minipass-json-stream": {
@@ -44899,6 +49233,16 @@
           "requires": {
             "jsonparse": "^1.3.1",
             "minipass": "^3.0.0"
+          },
+          "dependencies": {
+            "minipass": {
+              "version": "3.3.6",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "yallist": "^4.0.0"
+              }
+            }
           }
         },
         "minipass-pipeline": {
@@ -44907,6 +49251,16 @@
           "dev": true,
           "requires": {
             "minipass": "^3.0.0"
+          },
+          "dependencies": {
+            "minipass": {
+              "version": "3.3.6",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "yallist": "^4.0.0"
+              }
+            }
           }
         },
         "minipass-sized": {
@@ -44915,6 +49269,16 @@
           "dev": true,
           "requires": {
             "minipass": "^3.0.0"
+          },
+          "dependencies": {
+            "minipass": {
+              "version": "3.3.6",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "yallist": "^4.0.0"
+              }
+            }
           }
         },
         "minizlib": {
@@ -44924,6 +49288,16 @@
           "requires": {
             "minipass": "^3.0.0",
             "yallist": "^4.0.0"
+          },
+          "dependencies": {
+            "minipass": {
+              "version": "3.3.6",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "yallist": "^4.0.0"
+              }
+            }
           }
         },
         "mkdirp": {
@@ -44931,23 +49305,13 @@
           "bundled": true,
           "dev": true
         },
-        "mkdirp-infer-owner": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "chownr": "^2.0.0",
-            "infer-owner": "^1.0.4",
-            "mkdirp": "^1.0.3"
-          }
-        },
         "ms": {
           "version": "2.1.3",
           "bundled": true,
           "dev": true
         },
         "mute-stream": {
-          "version": "0.0.8",
+          "version": "1.0.0",
           "bundled": true,
           "dev": true
         },
@@ -44957,15 +49321,16 @@
           "dev": true
         },
         "node-gyp": {
-          "version": "9.0.0",
+          "version": "9.4.1",
           "bundled": true,
           "dev": true,
           "requires": {
             "env-paths": "^2.2.0",
+            "exponential-backoff": "^3.1.1",
             "glob": "^7.1.4",
             "graceful-fs": "^4.2.6",
             "make-fetch-happen": "^10.0.3",
-            "nopt": "^5.0.0",
+            "nopt": "^6.0.0",
             "npmlog": "^6.0.0",
             "rimraf": "^3.0.2",
             "semver": "^7.3.5",
@@ -44973,6 +49338,29 @@
             "which": "^2.0.2"
           },
           "dependencies": {
+            "@npmcli/fs": {
+              "version": "2.1.2",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "@gar/promisify": "^1.1.3",
+                "semver": "^7.3.5"
+              }
+            },
+            "abbrev": {
+              "version": "1.1.1",
+              "bundled": true,
+              "dev": true
+            },
+            "are-we-there-yet": {
+              "version": "3.0.1",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "delegates": "^1.0.0",
+                "readable-stream": "^3.6.0"
+              }
+            },
             "brace-expansion": {
               "version": "1.1.11",
               "bundled": true,
@@ -44980,6 +49368,84 @@
               "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
+              }
+            },
+            "cacache": {
+              "version": "16.1.3",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "@npmcli/fs": "^2.1.0",
+                "@npmcli/move-file": "^2.0.0",
+                "chownr": "^2.0.0",
+                "fs-minipass": "^2.1.0",
+                "glob": "^8.0.1",
+                "infer-owner": "^1.0.4",
+                "lru-cache": "^7.7.1",
+                "minipass": "^3.1.6",
+                "minipass-collect": "^1.0.2",
+                "minipass-flush": "^1.0.5",
+                "minipass-pipeline": "^1.2.4",
+                "mkdirp": "^1.0.4",
+                "p-map": "^4.0.0",
+                "promise-inflight": "^1.0.1",
+                "rimraf": "^3.0.2",
+                "ssri": "^9.0.0",
+                "tar": "^6.1.11",
+                "unique-filename": "^2.0.0"
+              },
+              "dependencies": {
+                "brace-expansion": {
+                  "version": "2.0.1",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "balanced-match": "^1.0.0"
+                  }
+                },
+                "glob": {
+                  "version": "8.1.0",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "fs.realpath": "^1.0.0",
+                    "inflight": "^1.0.4",
+                    "inherits": "2",
+                    "minimatch": "^5.0.1",
+                    "once": "^1.3.0"
+                  }
+                },
+                "minimatch": {
+                  "version": "5.1.6",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "brace-expansion": "^2.0.1"
+                  }
+                }
+              }
+            },
+            "fs-minipass": {
+              "version": "2.1.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "minipass": "^3.0.0"
+              }
+            },
+            "gauge": {
+              "version": "4.0.4",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "aproba": "^1.0.3 || ^2.0.0",
+                "color-support": "^1.1.3",
+                "console-control-strings": "^1.1.0",
+                "has-unicode": "^2.0.1",
+                "signal-exit": "^3.0.7",
+                "string-width": "^4.2.3",
+                "strip-ansi": "^6.0.1",
+                "wide-align": "^1.1.5"
               }
             },
             "glob": {
@@ -44995,6 +49461,29 @@
                 "path-is-absolute": "^1.0.0"
               }
             },
+            "make-fetch-happen": {
+              "version": "10.2.1",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "agentkeepalive": "^4.2.1",
+                "cacache": "^16.1.0",
+                "http-cache-semantics": "^4.1.0",
+                "http-proxy-agent": "^5.0.0",
+                "https-proxy-agent": "^5.0.0",
+                "is-lambda": "^1.0.1",
+                "lru-cache": "^7.7.1",
+                "minipass": "^3.1.6",
+                "minipass-collect": "^1.0.2",
+                "minipass-fetch": "^2.0.3",
+                "minipass-flush": "^1.0.5",
+                "minipass-pipeline": "^1.2.4",
+                "negotiator": "^0.6.3",
+                "promise-retry": "^2.0.1",
+                "socks-proxy-agent": "^7.0.0",
+                "ssri": "^9.0.0"
+              }
+            },
             "minimatch": {
               "version": "3.1.2",
               "bundled": true,
@@ -45002,46 +49491,118 @@
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
+            },
+            "minipass": {
+              "version": "3.3.6",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "yallist": "^4.0.0"
+              }
+            },
+            "minipass-fetch": {
+              "version": "2.1.2",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "encoding": "^0.1.13",
+                "minipass": "^3.1.6",
+                "minipass-sized": "^1.0.3",
+                "minizlib": "^2.1.2"
+              }
+            },
+            "nopt": {
+              "version": "6.0.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "abbrev": "^1.0.0"
+              }
+            },
+            "npmlog": {
+              "version": "6.0.2",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "are-we-there-yet": "^3.0.0",
+                "console-control-strings": "^1.1.0",
+                "gauge": "^4.0.3",
+                "set-blocking": "^2.0.0"
+              }
+            },
+            "signal-exit": {
+              "version": "3.0.7",
+              "bundled": true,
+              "dev": true
+            },
+            "ssri": {
+              "version": "9.0.1",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "minipass": "^3.1.1"
+              }
+            },
+            "unique-filename": {
+              "version": "2.0.1",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "unique-slug": "^3.0.0"
+              }
+            },
+            "unique-slug": {
+              "version": "3.0.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "imurmurhash": "^0.1.4"
+              }
+            },
+            "which": {
+              "version": "2.0.2",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "isexe": "^2.0.0"
+              }
             }
           }
         },
         "nopt": {
+          "version": "7.2.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "abbrev": "^2.0.0"
+          }
+        },
+        "normalize-package-data": {
           "version": "5.0.0",
           "bundled": true,
           "dev": true,
           "requires": {
-            "abbrev": "1"
-          }
-        },
-        "normalize-package-data": {
-          "version": "4.0.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "hosted-git-info": "^5.0.0",
+            "hosted-git-info": "^6.0.0",
             "is-core-module": "^2.8.1",
             "semver": "^7.3.5",
             "validate-npm-package-license": "^3.0.4"
           }
         },
         "npm-audit-report": {
+          "version": "5.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "npm-bundled": {
           "version": "3.0.0",
           "bundled": true,
           "dev": true,
           "requires": {
-            "chalk": "^4.0.0"
-          }
-        },
-        "npm-bundled": {
-          "version": "1.1.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "npm-normalize-package-bin": "^1.0.1"
+            "npm-normalize-package-bin": "^3.0.0"
           }
         },
         "npm-install-checks": {
-          "version": "5.0.0",
+          "version": "6.3.0",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -45049,78 +49610,83 @@
           }
         },
         "npm-normalize-package-bin": {
-          "version": "1.0.1",
+          "version": "3.0.1",
           "bundled": true,
           "dev": true
         },
         "npm-package-arg": {
-          "version": "9.0.2",
+          "version": "10.1.0",
           "bundled": true,
           "dev": true,
           "requires": {
-            "hosted-git-info": "^5.0.0",
+            "hosted-git-info": "^6.0.0",
+            "proc-log": "^3.0.0",
             "semver": "^7.3.5",
-            "validate-npm-package-name": "^4.0.0"
+            "validate-npm-package-name": "^5.0.0"
           }
         },
         "npm-packlist": {
-          "version": "5.1.0",
+          "version": "7.0.4",
           "bundled": true,
           "dev": true,
           "requires": {
-            "glob": "^8.0.1",
-            "ignore-walk": "^5.0.1",
-            "npm-bundled": "^1.1.2",
-            "npm-normalize-package-bin": "^1.0.1"
+            "ignore-walk": "^6.0.0"
           }
         },
         "npm-pick-manifest": {
-          "version": "7.0.1",
+          "version": "8.0.2",
           "bundled": true,
           "dev": true,
           "requires": {
-            "npm-install-checks": "^5.0.0",
-            "npm-normalize-package-bin": "^1.0.1",
-            "npm-package-arg": "^9.0.0",
+            "npm-install-checks": "^6.0.0",
+            "npm-normalize-package-bin": "^3.0.0",
+            "npm-package-arg": "^10.0.0",
             "semver": "^7.3.5"
           }
         },
         "npm-profile": {
-          "version": "6.0.3",
+          "version": "7.0.1",
           "bundled": true,
           "dev": true,
           "requires": {
-            "npm-registry-fetch": "^13.0.1",
-            "proc-log": "^2.0.0"
+            "npm-registry-fetch": "^14.0.0",
+            "proc-log": "^3.0.0"
           }
         },
         "npm-registry-fetch": {
-          "version": "13.1.1",
+          "version": "14.0.5",
           "bundled": true,
           "dev": true,
           "requires": {
-            "make-fetch-happen": "^10.0.6",
-            "minipass": "^3.1.6",
-            "minipass-fetch": "^2.0.3",
+            "make-fetch-happen": "^11.0.0",
+            "minipass": "^5.0.0",
+            "minipass-fetch": "^3.0.0",
             "minipass-json-stream": "^1.0.1",
             "minizlib": "^2.1.2",
-            "npm-package-arg": "^9.0.1",
-            "proc-log": "^2.0.0"
+            "npm-package-arg": "^10.0.0",
+            "proc-log": "^3.0.0"
+          },
+          "dependencies": {
+            "minipass": {
+              "version": "5.0.0",
+              "bundled": true,
+              "dev": true
+            }
           }
         },
         "npm-user-validate": {
-          "version": "1.0.1",
+          "version": "2.0.0",
           "bundled": true,
           "dev": true
         },
         "npmlog": {
-          "version": "6.0.2",
+          "version": "7.0.1",
           "bundled": true,
           "dev": true,
           "requires": {
-            "are-we-there-yet": "^3.0.0",
+            "are-we-there-yet": "^4.0.0",
             "console-control-strings": "^1.1.0",
-            "gauge": "^4.0.3",
+            "gauge": "^5.0.0",
             "set-blocking": "^2.0.0"
           }
         },
@@ -45132,11 +49698,6 @@
             "wrappy": "1"
           }
         },
-        "opener": {
-          "version": "1.5.2",
-          "bundled": true,
-          "dev": true
-        },
         "p-map": {
           "version": "4.0.0",
           "bundled": true,
@@ -45146,40 +49707,44 @@
           }
         },
         "pacote": {
-          "version": "13.6.0",
+          "version": "15.2.0",
           "bundled": true,
           "dev": true,
           "requires": {
-            "@npmcli/git": "^3.0.0",
-            "@npmcli/installed-package-contents": "^1.0.7",
-            "@npmcli/promise-spawn": "^3.0.0",
-            "@npmcli/run-script": "^3.0.1",
-            "cacache": "^16.0.0",
-            "chownr": "^2.0.0",
-            "fs-minipass": "^2.1.0",
-            "infer-owner": "^1.0.4",
-            "minipass": "^3.1.6",
-            "mkdirp": "^1.0.4",
-            "npm-package-arg": "^9.0.0",
-            "npm-packlist": "^5.1.0",
-            "npm-pick-manifest": "^7.0.0",
-            "npm-registry-fetch": "^13.0.1",
-            "proc-log": "^2.0.0",
+            "@npmcli/git": "^4.0.0",
+            "@npmcli/installed-package-contents": "^2.0.1",
+            "@npmcli/promise-spawn": "^6.0.1",
+            "@npmcli/run-script": "^6.0.0",
+            "cacache": "^17.0.0",
+            "fs-minipass": "^3.0.0",
+            "minipass": "^5.0.0",
+            "npm-package-arg": "^10.0.0",
+            "npm-packlist": "^7.0.0",
+            "npm-pick-manifest": "^8.0.0",
+            "npm-registry-fetch": "^14.0.0",
+            "proc-log": "^3.0.0",
             "promise-retry": "^2.0.1",
-            "read-package-json": "^5.0.0",
-            "read-package-json-fast": "^2.0.3",
-            "rimraf": "^3.0.2",
-            "ssri": "^9.0.0",
+            "read-package-json": "^6.0.0",
+            "read-package-json-fast": "^3.0.0",
+            "sigstore": "^1.3.0",
+            "ssri": "^10.0.0",
             "tar": "^6.1.11"
+          },
+          "dependencies": {
+            "minipass": {
+              "version": "5.0.0",
+              "bundled": true,
+              "dev": true
+            }
           }
         },
         "parse-conflict-json": {
-          "version": "2.0.2",
+          "version": "3.0.1",
           "bundled": true,
           "dev": true,
           "requires": {
-            "json-parse-even-better-errors": "^2.3.1",
-            "just-diff": "^5.0.1",
+            "json-parse-even-better-errors": "^3.0.0",
+            "just-diff": "^6.0.0",
             "just-diff-apply": "^5.2.0"
           }
         },
@@ -45188,8 +49753,38 @@
           "bundled": true,
           "dev": true
         },
+        "path-key": {
+          "version": "3.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "path-scurry": {
+          "version": "1.10.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "lru-cache": "^9.1.1 || ^10.0.0",
+            "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+          },
+          "dependencies": {
+            "lru-cache": {
+              "version": "10.2.0",
+              "bundled": true,
+              "dev": true
+            }
+          }
+        },
+        "postcss-selector-parser": {
+          "version": "6.0.15",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "cssesc": "^3.0.0",
+            "util-deprecate": "^1.0.2"
+          }
+        },
         "proc-log": {
-          "version": "2.0.1",
+          "version": "3.0.0",
           "bundled": true,
           "dev": true
         },
@@ -45199,7 +49794,7 @@
           "dev": true
         },
         "promise-call-limit": {
-          "version": "1.0.1",
+          "version": "1.0.2",
           "bundled": true,
           "dev": true
         },
@@ -45218,11 +49813,11 @@
           }
         },
         "promzard": {
-          "version": "0.3.0",
+          "version": "1.0.0",
           "bundled": true,
           "dev": true,
           "requires": {
-            "read": "1"
+            "read": "^2.0.0"
           }
         },
         "qrcode-terminal": {
@@ -45231,57 +49826,46 @@
           "dev": true
         },
         "read": {
-          "version": "1.0.7",
+          "version": "2.1.0",
           "bundled": true,
           "dev": true,
           "requires": {
-            "mute-stream": "~0.0.4"
+            "mute-stream": "~1.0.0"
           }
         },
         "read-cmd-shim": {
-          "version": "3.0.0",
+          "version": "4.0.0",
           "bundled": true,
           "dev": true
         },
         "read-package-json": {
-          "version": "5.0.1",
+          "version": "6.0.4",
           "bundled": true,
           "dev": true,
           "requires": {
-            "glob": "^8.0.1",
-            "json-parse-even-better-errors": "^2.3.1",
-            "normalize-package-data": "^4.0.0",
-            "npm-normalize-package-bin": "^1.0.1"
+            "glob": "^10.2.2",
+            "json-parse-even-better-errors": "^3.0.0",
+            "normalize-package-data": "^5.0.0",
+            "npm-normalize-package-bin": "^3.0.0"
           }
         },
         "read-package-json-fast": {
-          "version": "2.0.3",
+          "version": "3.0.2",
           "bundled": true,
           "dev": true,
           "requires": {
-            "json-parse-even-better-errors": "^2.3.0",
-            "npm-normalize-package-bin": "^1.0.1"
+            "json-parse-even-better-errors": "^3.0.0",
+            "npm-normalize-package-bin": "^3.0.0"
           }
         },
         "readable-stream": {
-          "version": "3.6.0",
+          "version": "3.6.2",
           "bundled": true,
           "dev": true,
           "requires": {
             "inherits": "^2.0.3",
             "string_decoder": "^1.1.1",
             "util-deprecate": "^1.0.1"
-          }
-        },
-        "readdir-scoped-modules": {
-          "version": "1.1.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "debuglog": "^1.0.1",
-            "dezalgo": "^1.0.0",
-            "graceful-fs": "^4.1.2",
-            "once": "^1.3.0"
           }
         },
         "retry": {
@@ -45341,7 +49925,7 @@
           "optional": true
         },
         "semver": {
-          "version": "7.3.7",
+          "version": "7.6.0",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -45363,10 +49947,35 @@
           "bundled": true,
           "dev": true
         },
-        "signal-exit": {
-          "version": "3.0.7",
+        "shebang-command": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "shebang-regex": "^3.0.0"
+          }
+        },
+        "shebang-regex": {
+          "version": "3.0.0",
           "bundled": true,
           "dev": true
+        },
+        "signal-exit": {
+          "version": "4.1.0",
+          "bundled": true,
+          "dev": true
+        },
+        "sigstore": {
+          "version": "1.9.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "@sigstore/bundle": "^1.1.0",
+            "@sigstore/protobuf-specs": "^0.2.0",
+            "@sigstore/sign": "^1.0.0",
+            "@sigstore/tuf": "^1.0.3",
+            "make-fetch-happen": "^11.0.1"
+          }
         },
         "smart-buffer": {
           "version": "4.2.0",
@@ -45374,16 +49983,16 @@
           "dev": true
         },
         "socks": {
-          "version": "2.6.2",
+          "version": "2.8.1",
           "bundled": true,
           "dev": true,
           "requires": {
-            "ip": "^1.1.5",
+            "ip-address": "^9.0.5",
             "smart-buffer": "^4.2.0"
           }
         },
         "socks-proxy-agent": {
-          "version": "6.2.0",
+          "version": "7.0.0",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -45393,7 +50002,7 @@
           }
         },
         "spdx-correct": {
-          "version": "3.1.1",
+          "version": "3.2.0",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -45402,7 +50011,7 @@
           }
         },
         "spdx-exceptions": {
-          "version": "2.3.0",
+          "version": "2.5.0",
           "bundled": true,
           "dev": true
         },
@@ -45416,16 +50025,16 @@
           }
         },
         "spdx-license-ids": {
-          "version": "3.0.11",
+          "version": "3.0.17",
           "bundled": true,
           "dev": true
         },
         "ssri": {
-          "version": "9.0.1",
+          "version": "10.0.5",
           "bundled": true,
           "dev": true,
           "requires": {
-            "minipass": "^3.1.1"
+            "minipass": "^7.0.3"
           }
         },
         "string_decoder": {
@@ -45446,6 +50055,16 @@
             "strip-ansi": "^6.0.1"
           }
         },
+        "string-width-cjs": {
+          "version": "npm:string-width@4.2.3",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "emoji-regex": "^8.0.0",
+            "is-fullwidth-code-point": "^3.0.0",
+            "strip-ansi": "^6.0.1"
+          }
+        },
         "strip-ansi": {
           "version": "6.0.1",
           "bundled": true,
@@ -45454,25 +50073,55 @@
             "ansi-regex": "^5.0.1"
           }
         },
-        "supports-color": {
-          "version": "7.2.0",
+        "strip-ansi-cjs": {
+          "version": "npm:strip-ansi@6.0.1",
           "bundled": true,
           "dev": true,
           "requires": {
-            "has-flag": "^4.0.0"
+            "ansi-regex": "^5.0.1"
           }
         },
+        "supports-color": {
+          "version": "9.4.0",
+          "bundled": true,
+          "dev": true
+        },
         "tar": {
-          "version": "6.1.11",
+          "version": "6.2.1",
           "bundled": true,
           "dev": true,
           "requires": {
             "chownr": "^2.0.0",
             "fs-minipass": "^2.0.0",
-            "minipass": "^3.0.0",
+            "minipass": "^5.0.0",
             "minizlib": "^2.1.1",
             "mkdirp": "^1.0.3",
             "yallist": "^4.0.0"
+          },
+          "dependencies": {
+            "fs-minipass": {
+              "version": "2.1.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "minipass": "^3.0.0"
+              },
+              "dependencies": {
+                "minipass": {
+                  "version": "3.3.6",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "yallist": "^4.0.0"
+                  }
+                }
+              }
+            },
+            "minipass": {
+              "version": "5.0.0",
+              "bundled": true,
+              "dev": true
+            }
           }
         },
         "text-table": {
@@ -45486,20 +50135,30 @@
           "dev": true
         },
         "treeverse": {
-          "version": "2.0.0",
+          "version": "3.0.0",
           "bundled": true,
           "dev": true
         },
-        "unique-filename": {
-          "version": "1.1.1",
+        "tuf-js": {
+          "version": "1.1.7",
           "bundled": true,
           "dev": true,
           "requires": {
-            "unique-slug": "^2.0.0"
+            "@tufjs/models": "1.0.4",
+            "debug": "^4.3.4",
+            "make-fetch-happen": "^11.1.1"
+          }
+        },
+        "unique-filename": {
+          "version": "3.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "unique-slug": "^4.0.0"
           }
         },
         "unique-slug": {
-          "version": "2.0.2",
+          "version": "4.0.0",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -45521,7 +50180,7 @@
           }
         },
         "validate-npm-package-name": {
-          "version": "4.0.0",
+          "version": "5.0.0",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -45529,7 +50188,7 @@
           }
         },
         "walk-up-path": {
-          "version": "1.0.0",
+          "version": "3.0.1",
           "bundled": true,
           "dev": true
         },
@@ -45542,7 +50201,7 @@
           }
         },
         "which": {
-          "version": "2.0.2",
+          "version": "3.0.1",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -45557,18 +50216,73 @@
             "string-width": "^1.0.2 || 2 || 3 || 4"
           }
         },
+        "wrap-ansi": {
+          "version": "8.1.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^6.1.0",
+            "string-width": "^5.0.1",
+            "strip-ansi": "^7.0.1"
+          },
+          "dependencies": {
+            "ansi-regex": {
+              "version": "6.0.1",
+              "bundled": true,
+              "dev": true
+            },
+            "ansi-styles": {
+              "version": "6.2.1",
+              "bundled": true,
+              "dev": true
+            },
+            "emoji-regex": {
+              "version": "9.2.2",
+              "bundled": true,
+              "dev": true
+            },
+            "string-width": {
+              "version": "5.1.2",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "eastasianwidth": "^0.2.0",
+                "emoji-regex": "^9.2.2",
+                "strip-ansi": "^7.0.1"
+              }
+            },
+            "strip-ansi": {
+              "version": "7.1.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "ansi-regex": "^6.0.1"
+              }
+            }
+          }
+        },
+        "wrap-ansi-cjs": {
+          "version": "npm:wrap-ansi@7.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.0.0",
+            "string-width": "^4.1.0",
+            "strip-ansi": "^6.0.0"
+          }
+        },
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
           "dev": true
         },
         "write-file-atomic": {
-          "version": "4.0.1",
+          "version": "5.0.1",
           "bundled": true,
           "dev": true,
           "requires": {
             "imurmurhash": "^0.1.4",
-            "signal-exit": "^3.0.7"
+            "signal-exit": "^4.0.1"
           }
         },
         "yallist": {
@@ -46475,9 +51189,9 @@
       "dev": true
     },
     "picocolors": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
-      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
       "dev": true
     },
     "picomatch": {
@@ -47405,6 +52119,12 @@
         "sisteransi": "^1.0.5"
       }
     },
+    "proto-list": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
+      "integrity": "sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA==",
+      "dev": true
+    },
     "proxy-addr": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -47879,12 +52599,12 @@
       }
     },
     "registry-auth-token": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-4.2.1.tgz",
-      "integrity": "sha512-6gkSb4U6aWJB4SF2ZvLb76yCBjcvufXBqvvEx1HbmKPkutswjW1xNVRY0+daljIYRbogN7O0etYSlbiaEQyMyw==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-5.1.1.tgz",
+      "integrity": "sha512-P7B4+jq8DeD2nMsAcdfaqHbssgHtZ7Z5+++a5ask90fvmJ8p5je4mOa+wzu+DB4vQ5tdJV/xywY+UnVFeQLV5Q==",
       "dev": true,
       "requires": {
-        "rc": "^1.2.8"
+        "@pnpm/npm-conf": "^3.0.2"
       }
     },
     "regjsgen": {
@@ -48261,6 +52981,1867 @@
         "yargs": "^16.2.0"
       },
       "dependencies": {
+        "@semantic-release/npm": {
+          "version": "9.0.2",
+          "resolved": "https://registry.npmjs.org/@semantic-release/npm/-/npm-9.0.2.tgz",
+          "integrity": "sha512-zgsynF6McdzxPnFet+a4iO9HpAlARXOM5adz7VGVCvj0ne8wtL2ZOQoDV2wZPDmdEotDIbVeJjafhelZjs9j6g==",
+          "dev": true,
+          "requires": {
+            "@semantic-release/error": "^3.0.0",
+            "aggregate-error": "^3.0.0",
+            "execa": "^5.0.0",
+            "fs-extra": "^11.0.0",
+            "lodash": "^4.17.15",
+            "nerf-dart": "^1.0.0",
+            "normalize-url": "^6.0.0",
+            "npm": "^8.3.0",
+            "rc": "^1.2.8",
+            "read-pkg": "^5.0.0",
+            "registry-auth-token": "^5.0.0",
+            "semver": "^7.1.2",
+            "tempy": "^1.0.0"
+          }
+        },
+        "crypto-random-string": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-2.0.0.tgz",
+          "integrity": "sha512-v1plID3y9r/lPhviJ1wrXpLeyUIGAZ2SHNYTEapm7/8A9nLPoyvVp3RK/EPFqn5kEznyWgYZNsRtYYIWbuG8KA==",
+          "dev": true
+        },
+        "fs-extra": {
+          "version": "11.3.6",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.6.tgz",
+          "integrity": "sha512-w8ZNZr2mKIc7qeNaQ9AVPT1+iFaI+Avd4xudVOvdDJ8VytREi1Ft5Ih7hd9jjehod8vAM5GMsfQ/TpPf4EyoEA==",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.2.0",
+            "jsonfile": "^6.0.1",
+            "universalify": "^2.0.0"
+          }
+        },
+        "npm": {
+          "version": "8.19.4",
+          "resolved": "https://registry.npmjs.org/npm/-/npm-8.19.4.tgz",
+          "integrity": "sha512-3HANl8i9DKnUA89P4KEgVNN28EjSeDCmvEqbzOAuxCFDzdBZzjUl99zgnGpOUumvW5lvJo2HKcjrsc+tfyv1Hw==",
+          "dev": true,
+          "requires": {
+            "@isaacs/string-locale-compare": "^1.1.0",
+            "@npmcli/arborist": "^5.6.3",
+            "@npmcli/ci-detect": "^2.0.0",
+            "@npmcli/config": "^4.2.1",
+            "@npmcli/fs": "^2.1.0",
+            "@npmcli/map-workspaces": "^2.0.3",
+            "@npmcli/package-json": "^2.0.0",
+            "@npmcli/run-script": "^4.2.1",
+            "abbrev": "~1.1.1",
+            "archy": "~1.0.0",
+            "cacache": "^16.1.3",
+            "chalk": "^4.1.2",
+            "chownr": "^2.0.0",
+            "cli-columns": "^4.0.0",
+            "cli-table3": "^0.6.2",
+            "columnify": "^1.6.0",
+            "fastest-levenshtein": "^1.0.12",
+            "fs-minipass": "^2.1.0",
+            "glob": "^8.0.1",
+            "graceful-fs": "^4.2.10",
+            "hosted-git-info": "^5.2.1",
+            "ini": "^3.0.1",
+            "init-package-json": "^3.0.2",
+            "is-cidr": "^4.0.2",
+            "json-parse-even-better-errors": "^2.3.1",
+            "libnpmaccess": "^6.0.4",
+            "libnpmdiff": "^4.0.5",
+            "libnpmexec": "^4.0.14",
+            "libnpmfund": "^3.0.5",
+            "libnpmhook": "^8.0.4",
+            "libnpmorg": "^4.0.4",
+            "libnpmpack": "^4.1.3",
+            "libnpmpublish": "^6.0.5",
+            "libnpmsearch": "^5.0.4",
+            "libnpmteam": "^4.0.4",
+            "libnpmversion": "^3.0.7",
+            "make-fetch-happen": "^10.2.0",
+            "minimatch": "^5.1.0",
+            "minipass": "^3.1.6",
+            "minipass-pipeline": "^1.2.4",
+            "mkdirp": "^1.0.4",
+            "mkdirp-infer-owner": "^2.0.0",
+            "ms": "^2.1.2",
+            "node-gyp": "^9.1.0",
+            "nopt": "^6.0.0",
+            "npm-audit-report": "^3.0.0",
+            "npm-install-checks": "^5.0.0",
+            "npm-package-arg": "^9.1.0",
+            "npm-pick-manifest": "^7.0.2",
+            "npm-profile": "^6.2.0",
+            "npm-registry-fetch": "^13.3.1",
+            "npm-user-validate": "^1.0.1",
+            "npmlog": "^6.0.2",
+            "opener": "^1.5.2",
+            "p-map": "^4.0.0",
+            "pacote": "^13.6.2",
+            "parse-conflict-json": "^2.0.2",
+            "proc-log": "^2.0.1",
+            "qrcode-terminal": "^0.12.0",
+            "read": "~1.0.7",
+            "read-package-json": "^5.0.2",
+            "read-package-json-fast": "^2.0.3",
+            "readdir-scoped-modules": "^1.1.0",
+            "rimraf": "^3.0.2",
+            "semver": "^7.3.7",
+            "ssri": "^9.0.1",
+            "tar": "^6.1.11",
+            "text-table": "~0.2.0",
+            "tiny-relative-date": "^1.3.0",
+            "treeverse": "^2.0.0",
+            "validate-npm-package-name": "^4.0.0",
+            "which": "^2.0.2",
+            "write-file-atomic": "^4.0.1"
+          },
+          "dependencies": {
+            "@colors/colors": {
+              "version": "1.5.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "@gar/promisify": {
+              "version": "1.1.3",
+              "bundled": true,
+              "dev": true
+            },
+            "@isaacs/string-locale-compare": {
+              "version": "1.1.0",
+              "bundled": true,
+              "dev": true
+            },
+            "@npmcli/arborist": {
+              "version": "5.6.3",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "@isaacs/string-locale-compare": "^1.1.0",
+                "@npmcli/installed-package-contents": "^1.0.7",
+                "@npmcli/map-workspaces": "^2.0.3",
+                "@npmcli/metavuln-calculator": "^3.0.1",
+                "@npmcli/move-file": "^2.0.0",
+                "@npmcli/name-from-folder": "^1.0.1",
+                "@npmcli/node-gyp": "^2.0.0",
+                "@npmcli/package-json": "^2.0.0",
+                "@npmcli/query": "^1.2.0",
+                "@npmcli/run-script": "^4.1.3",
+                "bin-links": "^3.0.3",
+                "cacache": "^16.1.3",
+                "common-ancestor-path": "^1.0.1",
+                "hosted-git-info": "^5.2.1",
+                "json-parse-even-better-errors": "^2.3.1",
+                "json-stringify-nice": "^1.1.4",
+                "minimatch": "^5.1.0",
+                "mkdirp": "^1.0.4",
+                "mkdirp-infer-owner": "^2.0.0",
+                "nopt": "^6.0.0",
+                "npm-install-checks": "^5.0.0",
+                "npm-package-arg": "^9.0.0",
+                "npm-pick-manifest": "^7.0.2",
+                "npm-registry-fetch": "^13.0.0",
+                "npmlog": "^6.0.2",
+                "pacote": "^13.6.1",
+                "parse-conflict-json": "^2.0.1",
+                "proc-log": "^2.0.0",
+                "promise-all-reject-late": "^1.0.0",
+                "promise-call-limit": "^1.0.1",
+                "read-package-json-fast": "^2.0.2",
+                "readdir-scoped-modules": "^1.1.0",
+                "rimraf": "^3.0.2",
+                "semver": "^7.3.7",
+                "ssri": "^9.0.0",
+                "treeverse": "^2.0.0",
+                "walk-up-path": "^1.0.0"
+              }
+            },
+            "@npmcli/ci-detect": {
+              "version": "2.0.0",
+              "bundled": true,
+              "dev": true
+            },
+            "@npmcli/config": {
+              "version": "4.2.2",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "@npmcli/map-workspaces": "^2.0.2",
+                "ini": "^3.0.0",
+                "mkdirp-infer-owner": "^2.0.0",
+                "nopt": "^6.0.0",
+                "proc-log": "^2.0.0",
+                "read-package-json-fast": "^2.0.3",
+                "semver": "^7.3.5",
+                "walk-up-path": "^1.0.0"
+              }
+            },
+            "@npmcli/disparity-colors": {
+              "version": "2.0.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "ansi-styles": "^4.3.0"
+              }
+            },
+            "@npmcli/fs": {
+              "version": "2.1.2",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "@gar/promisify": "^1.1.3",
+                "semver": "^7.3.5"
+              }
+            },
+            "@npmcli/git": {
+              "version": "3.0.2",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "@npmcli/promise-spawn": "^3.0.0",
+                "lru-cache": "^7.4.4",
+                "mkdirp": "^1.0.4",
+                "npm-pick-manifest": "^7.0.0",
+                "proc-log": "^2.0.0",
+                "promise-inflight": "^1.0.1",
+                "promise-retry": "^2.0.1",
+                "semver": "^7.3.5",
+                "which": "^2.0.2"
+              }
+            },
+            "@npmcli/installed-package-contents": {
+              "version": "1.0.7",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "npm-bundled": "^1.1.1",
+                "npm-normalize-package-bin": "^1.0.1"
+              },
+              "dependencies": {
+                "npm-bundled": {
+                  "version": "1.1.2",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "npm-normalize-package-bin": "^1.0.1"
+                  }
+                }
+              }
+            },
+            "@npmcli/map-workspaces": {
+              "version": "2.0.4",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "@npmcli/name-from-folder": "^1.0.1",
+                "glob": "^8.0.1",
+                "minimatch": "^5.0.1",
+                "read-package-json-fast": "^2.0.3"
+              }
+            },
+            "@npmcli/metavuln-calculator": {
+              "version": "3.1.1",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "cacache": "^16.0.0",
+                "json-parse-even-better-errors": "^2.3.1",
+                "pacote": "^13.0.3",
+                "semver": "^7.3.5"
+              }
+            },
+            "@npmcli/move-file": {
+              "version": "2.0.1",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "mkdirp": "^1.0.4",
+                "rimraf": "^3.0.2"
+              }
+            },
+            "@npmcli/name-from-folder": {
+              "version": "1.0.1",
+              "bundled": true,
+              "dev": true
+            },
+            "@npmcli/node-gyp": {
+              "version": "2.0.0",
+              "bundled": true,
+              "dev": true
+            },
+            "@npmcli/package-json": {
+              "version": "2.0.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "json-parse-even-better-errors": "^2.3.1"
+              }
+            },
+            "@npmcli/promise-spawn": {
+              "version": "3.0.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "infer-owner": "^1.0.4"
+              }
+            },
+            "@npmcli/query": {
+              "version": "1.2.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "npm-package-arg": "^9.1.0",
+                "postcss-selector-parser": "^6.0.10",
+                "semver": "^7.3.7"
+              }
+            },
+            "@npmcli/run-script": {
+              "version": "4.2.1",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "@npmcli/node-gyp": "^2.0.0",
+                "@npmcli/promise-spawn": "^3.0.0",
+                "node-gyp": "^9.0.0",
+                "read-package-json-fast": "^2.0.3",
+                "which": "^2.0.2"
+              }
+            },
+            "@tootallnate/once": {
+              "version": "2.0.0",
+              "bundled": true,
+              "dev": true
+            },
+            "abbrev": {
+              "version": "1.1.1",
+              "bundled": true,
+              "dev": true
+            },
+            "agent-base": {
+              "version": "6.0.2",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "debug": "4"
+              }
+            },
+            "agentkeepalive": {
+              "version": "4.2.1",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "debug": "^4.1.0",
+                "depd": "^1.1.2",
+                "humanize-ms": "^1.2.1"
+              }
+            },
+            "aggregate-error": {
+              "version": "3.1.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "clean-stack": "^2.0.0",
+                "indent-string": "^4.0.0"
+              }
+            },
+            "ansi-regex": {
+              "version": "5.0.1",
+              "bundled": true,
+              "dev": true
+            },
+            "ansi-styles": {
+              "version": "4.3.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "color-convert": "^2.0.1"
+              }
+            },
+            "aproba": {
+              "version": "2.0.0",
+              "bundled": true,
+              "dev": true
+            },
+            "archy": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true
+            },
+            "are-we-there-yet": {
+              "version": "3.0.1",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "delegates": "^1.0.0",
+                "readable-stream": "^3.6.0"
+              }
+            },
+            "asap": {
+              "version": "2.0.6",
+              "bundled": true,
+              "dev": true
+            },
+            "balanced-match": {
+              "version": "1.0.2",
+              "bundled": true,
+              "dev": true
+            },
+            "bin-links": {
+              "version": "3.0.3",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "cmd-shim": "^5.0.0",
+                "mkdirp-infer-owner": "^2.0.0",
+                "npm-normalize-package-bin": "^2.0.0",
+                "read-cmd-shim": "^3.0.0",
+                "rimraf": "^3.0.0",
+                "write-file-atomic": "^4.0.0"
+              },
+              "dependencies": {
+                "npm-normalize-package-bin": {
+                  "version": "2.0.0",
+                  "bundled": true,
+                  "dev": true
+                }
+              }
+            },
+            "binary-extensions": {
+              "version": "2.2.0",
+              "bundled": true,
+              "dev": true
+            },
+            "brace-expansion": {
+              "version": "2.0.1",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "balanced-match": "^1.0.0"
+              }
+            },
+            "builtins": {
+              "version": "5.0.1",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "semver": "^7.0.0"
+              }
+            },
+            "cacache": {
+              "version": "16.1.3",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "@npmcli/fs": "^2.1.0",
+                "@npmcli/move-file": "^2.0.0",
+                "chownr": "^2.0.0",
+                "fs-minipass": "^2.1.0",
+                "glob": "^8.0.1",
+                "infer-owner": "^1.0.4",
+                "lru-cache": "^7.7.1",
+                "minipass": "^3.1.6",
+                "minipass-collect": "^1.0.2",
+                "minipass-flush": "^1.0.5",
+                "minipass-pipeline": "^1.2.4",
+                "mkdirp": "^1.0.4",
+                "p-map": "^4.0.0",
+                "promise-inflight": "^1.0.1",
+                "rimraf": "^3.0.2",
+                "ssri": "^9.0.0",
+                "tar": "^6.1.11",
+                "unique-filename": "^2.0.0"
+              }
+            },
+            "chalk": {
+              "version": "4.1.2",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "ansi-styles": "^4.1.0",
+                "supports-color": "^7.1.0"
+              }
+            },
+            "chownr": {
+              "version": "2.0.0",
+              "bundled": true,
+              "dev": true
+            },
+            "cidr-regex": {
+              "version": "3.1.1",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "ip-regex": "^4.1.0"
+              }
+            },
+            "clean-stack": {
+              "version": "2.2.0",
+              "bundled": true,
+              "dev": true
+            },
+            "cli-columns": {
+              "version": "4.0.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "string-width": "^4.2.3",
+                "strip-ansi": "^6.0.1"
+              }
+            },
+            "cli-table3": {
+              "version": "0.6.2",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "@colors/colors": "1.5.0",
+                "string-width": "^4.2.0"
+              }
+            },
+            "clone": {
+              "version": "1.0.4",
+              "bundled": true,
+              "dev": true
+            },
+            "cmd-shim": {
+              "version": "5.0.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "mkdirp-infer-owner": "^2.0.0"
+              }
+            },
+            "color-convert": {
+              "version": "2.0.1",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "color-name": "~1.1.4"
+              }
+            },
+            "color-name": {
+              "version": "1.1.4",
+              "bundled": true,
+              "dev": true
+            },
+            "color-support": {
+              "version": "1.1.3",
+              "bundled": true,
+              "dev": true
+            },
+            "columnify": {
+              "version": "1.6.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "strip-ansi": "^6.0.1",
+                "wcwidth": "^1.0.0"
+              }
+            },
+            "common-ancestor-path": {
+              "version": "1.0.1",
+              "bundled": true,
+              "dev": true
+            },
+            "concat-map": {
+              "version": "0.0.1",
+              "bundled": true,
+              "dev": true
+            },
+            "console-control-strings": {
+              "version": "1.1.0",
+              "bundled": true,
+              "dev": true
+            },
+            "cssesc": {
+              "version": "3.0.0",
+              "bundled": true,
+              "dev": true
+            },
+            "debug": {
+              "version": "4.3.4",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "ms": "2.1.2"
+              },
+              "dependencies": {
+                "ms": {
+                  "version": "2.1.2",
+                  "bundled": true,
+                  "dev": true
+                }
+              }
+            },
+            "debuglog": {
+              "version": "1.0.1",
+              "bundled": true,
+              "dev": true
+            },
+            "defaults": {
+              "version": "1.0.3",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "clone": "^1.0.2"
+              }
+            },
+            "delegates": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true
+            },
+            "depd": {
+              "version": "1.1.2",
+              "bundled": true,
+              "dev": true
+            },
+            "dezalgo": {
+              "version": "1.0.4",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "asap": "^2.0.0",
+                "wrappy": "1"
+              }
+            },
+            "diff": {
+              "version": "5.1.0",
+              "bundled": true,
+              "dev": true
+            },
+            "emoji-regex": {
+              "version": "8.0.0",
+              "bundled": true,
+              "dev": true
+            },
+            "encoding": {
+              "version": "0.1.13",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "iconv-lite": "^0.6.2"
+              }
+            },
+            "env-paths": {
+              "version": "2.2.1",
+              "bundled": true,
+              "dev": true
+            },
+            "err-code": {
+              "version": "2.0.3",
+              "bundled": true,
+              "dev": true
+            },
+            "fastest-levenshtein": {
+              "version": "1.0.12",
+              "bundled": true,
+              "dev": true
+            },
+            "fs-minipass": {
+              "version": "2.1.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "minipass": "^3.0.0"
+              }
+            },
+            "fs.realpath": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true
+            },
+            "function-bind": {
+              "version": "1.1.1",
+              "bundled": true,
+              "dev": true
+            },
+            "gauge": {
+              "version": "4.0.4",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "aproba": "^1.0.3 || ^2.0.0",
+                "color-support": "^1.1.3",
+                "console-control-strings": "^1.1.0",
+                "has-unicode": "^2.0.1",
+                "signal-exit": "^3.0.7",
+                "string-width": "^4.2.3",
+                "strip-ansi": "^6.0.1",
+                "wide-align": "^1.1.5"
+              }
+            },
+            "glob": {
+              "version": "8.0.3",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^5.0.1",
+                "once": "^1.3.0"
+              }
+            },
+            "graceful-fs": {
+              "version": "4.2.10",
+              "bundled": true,
+              "dev": true
+            },
+            "has": {
+              "version": "1.0.3",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "function-bind": "^1.1.1"
+              }
+            },
+            "has-flag": {
+              "version": "4.0.0",
+              "bundled": true,
+              "dev": true
+            },
+            "has-unicode": {
+              "version": "2.0.1",
+              "bundled": true,
+              "dev": true
+            },
+            "hosted-git-info": {
+              "version": "5.2.1",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "lru-cache": "^7.5.1"
+              }
+            },
+            "http-cache-semantics": {
+              "version": "4.1.1",
+              "bundled": true,
+              "dev": true
+            },
+            "http-proxy-agent": {
+              "version": "5.0.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "@tootallnate/once": "2",
+                "agent-base": "6",
+                "debug": "4"
+              }
+            },
+            "https-proxy-agent": {
+              "version": "5.0.1",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "agent-base": "6",
+                "debug": "4"
+              }
+            },
+            "humanize-ms": {
+              "version": "1.2.1",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "ms": "^2.0.0"
+              }
+            },
+            "iconv-lite": {
+              "version": "0.6.3",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "safer-buffer": ">= 2.1.2 < 3.0.0"
+              }
+            },
+            "ignore-walk": {
+              "version": "5.0.1",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "minimatch": "^5.0.1"
+              }
+            },
+            "imurmurhash": {
+              "version": "0.1.4",
+              "bundled": true,
+              "dev": true
+            },
+            "indent-string": {
+              "version": "4.0.0",
+              "bundled": true,
+              "dev": true
+            },
+            "infer-owner": {
+              "version": "1.0.4",
+              "bundled": true,
+              "dev": true
+            },
+            "inflight": {
+              "version": "1.0.6",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "once": "^1.3.0",
+                "wrappy": "1"
+              }
+            },
+            "inherits": {
+              "version": "2.0.4",
+              "bundled": true,
+              "dev": true
+            },
+            "ini": {
+              "version": "3.0.1",
+              "bundled": true,
+              "dev": true
+            },
+            "init-package-json": {
+              "version": "3.0.2",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "npm-package-arg": "^9.0.1",
+                "promzard": "^0.3.0",
+                "read": "^1.0.7",
+                "read-package-json": "^5.0.0",
+                "semver": "^7.3.5",
+                "validate-npm-package-license": "^3.0.4",
+                "validate-npm-package-name": "^4.0.0"
+              }
+            },
+            "ip": {
+              "version": "2.0.0",
+              "bundled": true,
+              "dev": true
+            },
+            "ip-regex": {
+              "version": "4.3.0",
+              "bundled": true,
+              "dev": true
+            },
+            "is-cidr": {
+              "version": "4.0.2",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "cidr-regex": "^3.1.1"
+              }
+            },
+            "is-core-module": {
+              "version": "2.10.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "has": "^1.0.3"
+              }
+            },
+            "is-fullwidth-code-point": {
+              "version": "3.0.0",
+              "bundled": true,
+              "dev": true
+            },
+            "is-lambda": {
+              "version": "1.0.1",
+              "bundled": true,
+              "dev": true
+            },
+            "isexe": {
+              "version": "2.0.0",
+              "bundled": true,
+              "dev": true
+            },
+            "json-parse-even-better-errors": {
+              "version": "2.3.1",
+              "bundled": true,
+              "dev": true
+            },
+            "json-stringify-nice": {
+              "version": "1.1.4",
+              "bundled": true,
+              "dev": true
+            },
+            "jsonparse": {
+              "version": "1.3.1",
+              "bundled": true,
+              "dev": true
+            },
+            "just-diff": {
+              "version": "5.1.1",
+              "bundled": true,
+              "dev": true
+            },
+            "just-diff-apply": {
+              "version": "5.4.1",
+              "bundled": true,
+              "dev": true
+            },
+            "libnpmaccess": {
+              "version": "6.0.4",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "aproba": "^2.0.0",
+                "minipass": "^3.1.1",
+                "npm-package-arg": "^9.0.1",
+                "npm-registry-fetch": "^13.0.0"
+              }
+            },
+            "libnpmdiff": {
+              "version": "4.0.5",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "@npmcli/disparity-colors": "^2.0.0",
+                "@npmcli/installed-package-contents": "^1.0.7",
+                "binary-extensions": "^2.2.0",
+                "diff": "^5.1.0",
+                "minimatch": "^5.0.1",
+                "npm-package-arg": "^9.0.1",
+                "pacote": "^13.6.1",
+                "tar": "^6.1.0"
+              }
+            },
+            "libnpmexec": {
+              "version": "4.0.14",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "@npmcli/arborist": "^5.6.3",
+                "@npmcli/ci-detect": "^2.0.0",
+                "@npmcli/fs": "^2.1.1",
+                "@npmcli/run-script": "^4.2.0",
+                "chalk": "^4.1.0",
+                "mkdirp-infer-owner": "^2.0.0",
+                "npm-package-arg": "^9.0.1",
+                "npmlog": "^6.0.2",
+                "pacote": "^13.6.1",
+                "proc-log": "^2.0.0",
+                "read": "^1.0.7",
+                "read-package-json-fast": "^2.0.2",
+                "semver": "^7.3.7",
+                "walk-up-path": "^1.0.0"
+              }
+            },
+            "libnpmfund": {
+              "version": "3.0.5",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "@npmcli/arborist": "^5.6.3"
+              }
+            },
+            "libnpmhook": {
+              "version": "8.0.4",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "aproba": "^2.0.0",
+                "npm-registry-fetch": "^13.0.0"
+              }
+            },
+            "libnpmorg": {
+              "version": "4.0.4",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "aproba": "^2.0.0",
+                "npm-registry-fetch": "^13.0.0"
+              }
+            },
+            "libnpmpack": {
+              "version": "4.1.3",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "@npmcli/run-script": "^4.1.3",
+                "npm-package-arg": "^9.0.1",
+                "pacote": "^13.6.1"
+              }
+            },
+            "libnpmpublish": {
+              "version": "6.0.5",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "normalize-package-data": "^4.0.0",
+                "npm-package-arg": "^9.0.1",
+                "npm-registry-fetch": "^13.0.0",
+                "semver": "^7.3.7",
+                "ssri": "^9.0.0"
+              }
+            },
+            "libnpmsearch": {
+              "version": "5.0.4",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "npm-registry-fetch": "^13.0.0"
+              }
+            },
+            "libnpmteam": {
+              "version": "4.0.4",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "aproba": "^2.0.0",
+                "npm-registry-fetch": "^13.0.0"
+              }
+            },
+            "libnpmversion": {
+              "version": "3.0.7",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "@npmcli/git": "^3.0.0",
+                "@npmcli/run-script": "^4.1.3",
+                "json-parse-even-better-errors": "^2.3.1",
+                "proc-log": "^2.0.0",
+                "semver": "^7.3.7"
+              }
+            },
+            "lru-cache": {
+              "version": "7.13.2",
+              "bundled": true,
+              "dev": true
+            },
+            "make-fetch-happen": {
+              "version": "10.2.1",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "agentkeepalive": "^4.2.1",
+                "cacache": "^16.1.0",
+                "http-cache-semantics": "^4.1.0",
+                "http-proxy-agent": "^5.0.0",
+                "https-proxy-agent": "^5.0.0",
+                "is-lambda": "^1.0.1",
+                "lru-cache": "^7.7.1",
+                "minipass": "^3.1.6",
+                "minipass-collect": "^1.0.2",
+                "minipass-fetch": "^2.0.3",
+                "minipass-flush": "^1.0.5",
+                "minipass-pipeline": "^1.2.4",
+                "negotiator": "^0.6.3",
+                "promise-retry": "^2.0.1",
+                "socks-proxy-agent": "^7.0.0",
+                "ssri": "^9.0.0"
+              }
+            },
+            "minimatch": {
+              "version": "5.1.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "brace-expansion": "^2.0.1"
+              }
+            },
+            "minipass": {
+              "version": "3.3.4",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "yallist": "^4.0.0"
+              }
+            },
+            "minipass-collect": {
+              "version": "1.0.2",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "minipass": "^3.0.0"
+              }
+            },
+            "minipass-fetch": {
+              "version": "2.1.1",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "encoding": "^0.1.13",
+                "minipass": "^3.1.6",
+                "minipass-sized": "^1.0.3",
+                "minizlib": "^2.1.2"
+              }
+            },
+            "minipass-flush": {
+              "version": "1.0.5",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "minipass": "^3.0.0"
+              }
+            },
+            "minipass-json-stream": {
+              "version": "1.0.1",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "jsonparse": "^1.3.1",
+                "minipass": "^3.0.0"
+              }
+            },
+            "minipass-pipeline": {
+              "version": "1.2.4",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "minipass": "^3.0.0"
+              }
+            },
+            "minipass-sized": {
+              "version": "1.0.3",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "minipass": "^3.0.0"
+              }
+            },
+            "minizlib": {
+              "version": "2.1.2",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "minipass": "^3.0.0",
+                "yallist": "^4.0.0"
+              }
+            },
+            "mkdirp": {
+              "version": "1.0.4",
+              "bundled": true,
+              "dev": true
+            },
+            "mkdirp-infer-owner": {
+              "version": "2.0.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "chownr": "^2.0.0",
+                "infer-owner": "^1.0.4",
+                "mkdirp": "^1.0.3"
+              }
+            },
+            "ms": {
+              "version": "2.1.3",
+              "bundled": true,
+              "dev": true
+            },
+            "mute-stream": {
+              "version": "0.0.8",
+              "bundled": true,
+              "dev": true
+            },
+            "negotiator": {
+              "version": "0.6.3",
+              "bundled": true,
+              "dev": true
+            },
+            "node-gyp": {
+              "version": "9.1.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "env-paths": "^2.2.0",
+                "glob": "^7.1.4",
+                "graceful-fs": "^4.2.6",
+                "make-fetch-happen": "^10.0.3",
+                "nopt": "^5.0.0",
+                "npmlog": "^6.0.0",
+                "rimraf": "^3.0.2",
+                "semver": "^7.3.5",
+                "tar": "^6.1.2",
+                "which": "^2.0.2"
+              },
+              "dependencies": {
+                "brace-expansion": {
+                  "version": "1.1.11",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "balanced-match": "^1.0.0",
+                    "concat-map": "0.0.1"
+                  }
+                },
+                "glob": {
+                  "version": "7.2.3",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "fs.realpath": "^1.0.0",
+                    "inflight": "^1.0.4",
+                    "inherits": "2",
+                    "minimatch": "^3.1.1",
+                    "once": "^1.3.0",
+                    "path-is-absolute": "^1.0.0"
+                  }
+                },
+                "minimatch": {
+                  "version": "3.1.2",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "brace-expansion": "^1.1.7"
+                  }
+                },
+                "nopt": {
+                  "version": "5.0.0",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "abbrev": "1"
+                  }
+                }
+              }
+            },
+            "nopt": {
+              "version": "6.0.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "abbrev": "^1.0.0"
+              }
+            },
+            "normalize-package-data": {
+              "version": "4.0.1",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "hosted-git-info": "^5.0.0",
+                "is-core-module": "^2.8.1",
+                "semver": "^7.3.5",
+                "validate-npm-package-license": "^3.0.4"
+              }
+            },
+            "npm-audit-report": {
+              "version": "3.0.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "chalk": "^4.0.0"
+              }
+            },
+            "npm-bundled": {
+              "version": "2.0.1",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "npm-normalize-package-bin": "^2.0.0"
+              },
+              "dependencies": {
+                "npm-normalize-package-bin": {
+                  "version": "2.0.0",
+                  "bundled": true,
+                  "dev": true
+                }
+              }
+            },
+            "npm-install-checks": {
+              "version": "5.0.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "semver": "^7.1.1"
+              }
+            },
+            "npm-normalize-package-bin": {
+              "version": "1.0.1",
+              "bundled": true,
+              "dev": true
+            },
+            "npm-package-arg": {
+              "version": "9.1.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "hosted-git-info": "^5.0.0",
+                "proc-log": "^2.0.1",
+                "semver": "^7.3.5",
+                "validate-npm-package-name": "^4.0.0"
+              }
+            },
+            "npm-packlist": {
+              "version": "5.1.3",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "glob": "^8.0.1",
+                "ignore-walk": "^5.0.1",
+                "npm-bundled": "^2.0.0",
+                "npm-normalize-package-bin": "^2.0.0"
+              },
+              "dependencies": {
+                "npm-normalize-package-bin": {
+                  "version": "2.0.0",
+                  "bundled": true,
+                  "dev": true
+                }
+              }
+            },
+            "npm-pick-manifest": {
+              "version": "7.0.2",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "npm-install-checks": "^5.0.0",
+                "npm-normalize-package-bin": "^2.0.0",
+                "npm-package-arg": "^9.0.0",
+                "semver": "^7.3.5"
+              },
+              "dependencies": {
+                "npm-normalize-package-bin": {
+                  "version": "2.0.0",
+                  "bundled": true,
+                  "dev": true
+                }
+              }
+            },
+            "npm-profile": {
+              "version": "6.2.1",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "npm-registry-fetch": "^13.0.1",
+                "proc-log": "^2.0.0"
+              }
+            },
+            "npm-registry-fetch": {
+              "version": "13.3.1",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "make-fetch-happen": "^10.0.6",
+                "minipass": "^3.1.6",
+                "minipass-fetch": "^2.0.3",
+                "minipass-json-stream": "^1.0.1",
+                "minizlib": "^2.1.2",
+                "npm-package-arg": "^9.0.1",
+                "proc-log": "^2.0.0"
+              }
+            },
+            "npm-user-validate": {
+              "version": "1.0.1",
+              "bundled": true,
+              "dev": true
+            },
+            "npmlog": {
+              "version": "6.0.2",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "are-we-there-yet": "^3.0.0",
+                "console-control-strings": "^1.1.0",
+                "gauge": "^4.0.3",
+                "set-blocking": "^2.0.0"
+              }
+            },
+            "once": {
+              "version": "1.4.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "wrappy": "1"
+              }
+            },
+            "opener": {
+              "version": "1.5.2",
+              "bundled": true,
+              "dev": true
+            },
+            "p-map": {
+              "version": "4.0.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "aggregate-error": "^3.0.0"
+              }
+            },
+            "pacote": {
+              "version": "13.6.2",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "@npmcli/git": "^3.0.0",
+                "@npmcli/installed-package-contents": "^1.0.7",
+                "@npmcli/promise-spawn": "^3.0.0",
+                "@npmcli/run-script": "^4.1.0",
+                "cacache": "^16.0.0",
+                "chownr": "^2.0.0",
+                "fs-minipass": "^2.1.0",
+                "infer-owner": "^1.0.4",
+                "minipass": "^3.1.6",
+                "mkdirp": "^1.0.4",
+                "npm-package-arg": "^9.0.0",
+                "npm-packlist": "^5.1.0",
+                "npm-pick-manifest": "^7.0.0",
+                "npm-registry-fetch": "^13.0.1",
+                "proc-log": "^2.0.0",
+                "promise-retry": "^2.0.1",
+                "read-package-json": "^5.0.0",
+                "read-package-json-fast": "^2.0.3",
+                "rimraf": "^3.0.2",
+                "ssri": "^9.0.0",
+                "tar": "^6.1.11"
+              }
+            },
+            "parse-conflict-json": {
+              "version": "2.0.2",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "json-parse-even-better-errors": "^2.3.1",
+                "just-diff": "^5.0.1",
+                "just-diff-apply": "^5.2.0"
+              }
+            },
+            "path-is-absolute": {
+              "version": "1.0.1",
+              "bundled": true,
+              "dev": true
+            },
+            "postcss-selector-parser": {
+              "version": "6.0.10",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "cssesc": "^3.0.0",
+                "util-deprecate": "^1.0.2"
+              }
+            },
+            "proc-log": {
+              "version": "2.0.1",
+              "bundled": true,
+              "dev": true
+            },
+            "promise-all-reject-late": {
+              "version": "1.0.1",
+              "bundled": true,
+              "dev": true
+            },
+            "promise-call-limit": {
+              "version": "1.0.1",
+              "bundled": true,
+              "dev": true
+            },
+            "promise-inflight": {
+              "version": "1.0.1",
+              "bundled": true,
+              "dev": true
+            },
+            "promise-retry": {
+              "version": "2.0.1",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "err-code": "^2.0.2",
+                "retry": "^0.12.0"
+              }
+            },
+            "promzard": {
+              "version": "0.3.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "read": "1"
+              }
+            },
+            "qrcode-terminal": {
+              "version": "0.12.0",
+              "bundled": true,
+              "dev": true
+            },
+            "read": {
+              "version": "1.0.7",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "mute-stream": "~0.0.4"
+              }
+            },
+            "read-cmd-shim": {
+              "version": "3.0.0",
+              "bundled": true,
+              "dev": true
+            },
+            "read-package-json": {
+              "version": "5.0.2",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "glob": "^8.0.1",
+                "json-parse-even-better-errors": "^2.3.1",
+                "normalize-package-data": "^4.0.0",
+                "npm-normalize-package-bin": "^2.0.0"
+              },
+              "dependencies": {
+                "npm-normalize-package-bin": {
+                  "version": "2.0.0",
+                  "bundled": true,
+                  "dev": true
+                }
+              }
+            },
+            "read-package-json-fast": {
+              "version": "2.0.3",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "json-parse-even-better-errors": "^2.3.0",
+                "npm-normalize-package-bin": "^1.0.1"
+              }
+            },
+            "readable-stream": {
+              "version": "3.6.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "inherits": "^2.0.3",
+                "string_decoder": "^1.1.1",
+                "util-deprecate": "^1.0.1"
+              }
+            },
+            "readdir-scoped-modules": {
+              "version": "1.1.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "debuglog": "^1.0.1",
+                "dezalgo": "^1.0.0",
+                "graceful-fs": "^4.1.2",
+                "once": "^1.3.0"
+              }
+            },
+            "retry": {
+              "version": "0.12.0",
+              "bundled": true,
+              "dev": true
+            },
+            "rimraf": {
+              "version": "3.0.2",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "glob": "^7.1.3"
+              },
+              "dependencies": {
+                "brace-expansion": {
+                  "version": "1.1.11",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "balanced-match": "^1.0.0",
+                    "concat-map": "0.0.1"
+                  }
+                },
+                "glob": {
+                  "version": "7.2.3",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "fs.realpath": "^1.0.0",
+                    "inflight": "^1.0.4",
+                    "inherits": "2",
+                    "minimatch": "^3.1.1",
+                    "once": "^1.3.0",
+                    "path-is-absolute": "^1.0.0"
+                  }
+                },
+                "minimatch": {
+                  "version": "3.1.2",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "brace-expansion": "^1.1.7"
+                  }
+                }
+              }
+            },
+            "safe-buffer": {
+              "version": "5.2.1",
+              "bundled": true,
+              "dev": true
+            },
+            "safer-buffer": {
+              "version": "2.1.2",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "semver": {
+              "version": "7.3.7",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "lru-cache": "^6.0.0"
+              },
+              "dependencies": {
+                "lru-cache": {
+                  "version": "6.0.0",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "yallist": "^4.0.0"
+                  }
+                }
+              }
+            },
+            "set-blocking": {
+              "version": "2.0.0",
+              "bundled": true,
+              "dev": true
+            },
+            "signal-exit": {
+              "version": "3.0.7",
+              "bundled": true,
+              "dev": true
+            },
+            "smart-buffer": {
+              "version": "4.2.0",
+              "bundled": true,
+              "dev": true
+            },
+            "socks": {
+              "version": "2.7.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "ip": "^2.0.0",
+                "smart-buffer": "^4.2.0"
+              }
+            },
+            "socks-proxy-agent": {
+              "version": "7.0.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "agent-base": "^6.0.2",
+                "debug": "^4.3.3",
+                "socks": "^2.6.2"
+              }
+            },
+            "spdx-correct": {
+              "version": "3.1.1",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "spdx-expression-parse": "^3.0.0",
+                "spdx-license-ids": "^3.0.0"
+              }
+            },
+            "spdx-exceptions": {
+              "version": "2.3.0",
+              "bundled": true,
+              "dev": true
+            },
+            "spdx-expression-parse": {
+              "version": "3.0.1",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "spdx-exceptions": "^2.1.0",
+                "spdx-license-ids": "^3.0.0"
+              }
+            },
+            "spdx-license-ids": {
+              "version": "3.0.11",
+              "bundled": true,
+              "dev": true
+            },
+            "ssri": {
+              "version": "9.0.1",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "minipass": "^3.1.1"
+              }
+            },
+            "string_decoder": {
+              "version": "1.3.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "safe-buffer": "~5.2.0"
+              }
+            },
+            "string-width": {
+              "version": "4.2.3",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "emoji-regex": "^8.0.0",
+                "is-fullwidth-code-point": "^3.0.0",
+                "strip-ansi": "^6.0.1"
+              }
+            },
+            "strip-ansi": {
+              "version": "6.0.1",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "ansi-regex": "^5.0.1"
+              }
+            },
+            "supports-color": {
+              "version": "7.2.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "has-flag": "^4.0.0"
+              }
+            },
+            "tar": {
+              "version": "6.1.11",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "chownr": "^2.0.0",
+                "fs-minipass": "^2.0.0",
+                "minipass": "^3.0.0",
+                "minizlib": "^2.1.1",
+                "mkdirp": "^1.0.3",
+                "yallist": "^4.0.0"
+              }
+            },
+            "text-table": {
+              "version": "0.2.0",
+              "bundled": true,
+              "dev": true
+            },
+            "tiny-relative-date": {
+              "version": "1.3.0",
+              "bundled": true,
+              "dev": true
+            },
+            "treeverse": {
+              "version": "2.0.0",
+              "bundled": true,
+              "dev": true
+            },
+            "unique-filename": {
+              "version": "2.0.1",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "unique-slug": "^3.0.0"
+              }
+            },
+            "unique-slug": {
+              "version": "3.0.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "imurmurhash": "^0.1.4"
+              }
+            },
+            "util-deprecate": {
+              "version": "1.0.2",
+              "bundled": true,
+              "dev": true
+            },
+            "validate-npm-package-license": {
+              "version": "3.0.4",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "spdx-correct": "^3.0.0",
+                "spdx-expression-parse": "^3.0.0"
+              }
+            },
+            "validate-npm-package-name": {
+              "version": "4.0.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "builtins": "^5.0.0"
+              }
+            },
+            "walk-up-path": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true
+            },
+            "wcwidth": {
+              "version": "1.0.1",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "defaults": "^1.0.3"
+              }
+            },
+            "which": {
+              "version": "2.0.2",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "isexe": "^2.0.0"
+              }
+            },
+            "wide-align": {
+              "version": "1.1.5",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "string-width": "^1.0.2 || 2 || 3 || 4"
+              }
+            },
+            "wrappy": {
+              "version": "1.0.2",
+              "bundled": true,
+              "dev": true
+            },
+            "write-file-atomic": {
+              "version": "4.0.2",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "imurmurhash": "^0.1.4",
+                "signal-exit": "^3.0.7"
+              }
+            },
+            "yallist": {
+              "version": "4.0.0",
+              "bundled": true,
+              "dev": true
+            }
+          }
+        },
+        "temp-dir": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/temp-dir/-/temp-dir-2.0.0.tgz",
+          "integrity": "sha512-aoBAniQmmwtcKp/7BzsH8Cxzv8OL736p7v1ihGb5e9DJ9kTwGWHrQrVB5+lfVDzfGrdRzXch+ig7LHaY1JTOrg==",
+          "dev": true
+        },
+        "tempy": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/tempy/-/tempy-1.0.1.tgz",
+          "integrity": "sha512-biM9brNqxSc04Ee71hzFbryD11nX7VPhQQY32AdDmjFvodsRFz/3ufeoTZ6uYkRFfGo188tENcASNs3vTdsM0w==",
+          "dev": true,
+          "requires": {
+            "del": "^6.0.0",
+            "is-stream": "^2.0.0",
+            "temp-dir": "^2.0.0",
+            "type-fest": "^0.16.0",
+            "unique-string": "^2.0.0"
+          }
+        },
+        "type-fest": {
+          "version": "0.16.0",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.16.0.tgz",
+          "integrity": "sha512-eaBzG6MxNzEn9kiwvtre90cXaNLkmadMWa1zQMs3XORCXNbsH/OewwbxC5ia9dCxIxnTAsSxXJaa/p5y8DlvJg==",
+          "dev": true
+        },
+        "unique-string": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-2.0.0.tgz",
+          "integrity": "sha512-uNaeirEPvpZWSgzwsPGtU2zVSTrn/8L5q/IexZmH0eH6SA73CmAA5U4GwORTxQAZs95TAXLNqeLoPPNO5gZfWg==",
+          "dev": true,
+          "requires": {
+            "crypto-random-string": "^2.0.0"
+          }
+        },
         "yargs": {
           "version": "16.2.0",
           "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
@@ -49171,28 +55752,33 @@
       }
     },
     "temp-dir": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/temp-dir/-/temp-dir-2.0.0.tgz",
-      "integrity": "sha512-aoBAniQmmwtcKp/7BzsH8Cxzv8OL736p7v1ihGb5e9DJ9kTwGWHrQrVB5+lfVDzfGrdRzXch+ig7LHaY1JTOrg==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/temp-dir/-/temp-dir-3.0.0.tgz",
+      "integrity": "sha512-nHc6S/bwIilKHNRgK/3jlhDoIHcp45YgyiwcAk46Tr0LfEqGBVpmiAyuiuxeVE44m3mXnEeVhaipLOEWmH+Njw==",
       "dev": true
     },
     "tempy": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/tempy/-/tempy-1.0.1.tgz",
-      "integrity": "sha512-biM9brNqxSc04Ee71hzFbryD11nX7VPhQQY32AdDmjFvodsRFz/3ufeoTZ6uYkRFfGo188tENcASNs3vTdsM0w==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/tempy/-/tempy-3.2.0.tgz",
+      "integrity": "sha512-d79HhZya5Djd7am0q+W4RTsSU+D/aJzM+4Y4AGJGuGlgM2L6sx5ZvOYTmZjqPhrDrV6xJTtRSm1JCLj6V6LHLQ==",
       "dev": true,
       "requires": {
-        "del": "^6.0.0",
-        "is-stream": "^2.0.0",
-        "temp-dir": "^2.0.0",
-        "type-fest": "^0.16.0",
-        "unique-string": "^2.0.0"
+        "is-stream": "^3.0.0",
+        "temp-dir": "^3.0.0",
+        "type-fest": "^2.12.2",
+        "unique-string": "^3.0.0"
       },
       "dependencies": {
+        "is-stream": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
+          "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
+          "dev": true
+        },
         "type-fest": {
-          "version": "0.16.0",
-          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.16.0.tgz",
-          "integrity": "sha512-eaBzG6MxNzEn9kiwvtre90cXaNLkmadMWa1zQMs3XORCXNbsH/OewwbxC5ia9dCxIxnTAsSxXJaa/p5y8DlvJg==",
+          "version": "2.19.0",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+          "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
           "dev": true
         }
       }
@@ -49833,12 +56419,12 @@
       }
     },
     "unique-string": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-2.0.0.tgz",
-      "integrity": "sha512-uNaeirEPvpZWSgzwsPGtU2zVSTrn/8L5q/IexZmH0eH6SA73CmAA5U4GwORTxQAZs95TAXLNqeLoPPNO5gZfWg==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-3.0.0.tgz",
+      "integrity": "sha512-VGXBUVwxKMBUznyffQweQABPRRW1vHZAbadFZud4pLFAqRGvv/96vafgjWFqzourzr8YonlQiPgH0YCJfawoGQ==",
       "dev": true,
       "requires": {
-        "crypto-random-string": "^2.0.0"
+        "crypto-random-string": "^4.0.0"
       }
     },
     "universal-user-agent": {

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "@semantic-release/exec": "^6.0.3",
     "@semantic-release/git": "^10.0.1",
     "@semantic-release/github": "^8.0.4",
-    "@semantic-release/npm": "^9.0.1",
+    "@semantic-release/npm": "^10.0.0",
     "@semantic-release/release-notes-generator": "^10.0.3",
     "@types/jest": "^28.1.1",
     "@types/node": "^16.11.11",


### PR DESCRIPTION
## Problem

The automated release workflow (Issue #537) is failing with **"No npm token specified"** error after migrating to NPM trusted publisher OIDC flow.

## Root Cause

`@semantic-release/npm@9.0.1` does not support npm trusted publisher OIDC authentication. It only checks for `NPM_TOKEN` env var or auth config in `.npmrc`. With the OIDC migration removing `NPM_TOKEN` and `registry-url` from `setup-node`, there's no authentication available for semantic-release.

## Fix

Upgraded `@semantic-release/npm` from `^9.0.1` to `^10.0.0`.

v10 adds native OIDC support, allowing semantic-release to use the GitHub Actions OIDC token directly via `id-token: write` permission — no `NPM_TOKEN` or `registry-url` needed.

## Changes

- `package.json`: `"@semantic-release/npm": "^9.0.1"` → `"^10.0.0"`

## Related

Fixes #537 (follow-up to #535)