### PR TITLE
fix(ci): add registry-url to setup-node for OIDC trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,6 +26,7 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: '24'
+          registry-url: 'https://registry.npmjs.org'
       - name: Install Deps
         run: npm ci --ignore-scripts
       - name: Build


### PR DESCRIPTION
Add `registry-url` to `actions/setup-node` so that the OIDC token is properly configured for npm authentication. This is required for `@semantic-release/npm@10` to authenticate with npm using trusted publishing (OIDC).