### PR TITLE
fix(ci): upgrade actions/setup-node to v4 for OIDC trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,8 +22,8 @@ jobs:
     runs-on: ubuntu-latest
     environment: release
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: '24'
           registry-url: 'https://registry.npmjs.org'


### PR DESCRIPTION
Upgrade `actions/setup-node` from v3 to v4 and `actions/checkout` from v3 to v4.

`actions/setup-node@v3` does not properly configure OIDC tokens for npm trusted publishing, causing `401 Unauthorized` errors when `@semantic-release/npm` tries to authenticate with the npm registry.

`actions/setup-node@v4` adds proper OIDC support for trusted publishing.